### PR TITLE
Move state handling logic outside components

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "3.5.6",
+    "@reduxjs/toolkit": "^1.9.0",
     "@sentry/react": "^7.17.3",
     "@sentry/tracing": "^7.17.3",
     "@types/classnames": "^2.2.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router';
-
+import { Provider } from 'react-redux';
 import { ClientProvider } from './client/ClientProvider';
 import StoreProvider from './client/redux/StoreProvider';
 import PageContainer from './components/PageContainer';
@@ -8,6 +8,7 @@ import HandleCallback from './components/HandleCallback';
 import Header from './components/Header';
 import LogOut from './pages/LogOut';
 import Index from './pages/Index';
+import store from './store';
 import ParkingFineAppeal from './components/parkingFineAppeal/ParkingFineAppeal';
 import ExtendDueDate from './components/extendDueDate/ExtendDueDate';
 
@@ -16,27 +17,29 @@ function App(): React.ReactElement {
     <HandleCallback>
       <ClientProvider>
         <StoreProvider>
-          <PageContainer>
-            <Header />
-            <Switch>
-              <Route path={'/'} exact>
-                <Index />
-              </Route>
-              <Route path={['/authError']} exact>
-                <div>Autentikaatio epäonnistui</div>
-              </Route>
-              <Route path={['/logout']} exact>
-                <LogOut />
-              </Route>
-              <Route path={['/oikaisuvaatimus']} exact>
-                <ParkingFineAppeal />
-              </Route>
-              <Route path={['/erapaivansiirto']} exact>
-                <ExtendDueDate />
-              </Route>
-              <Route path="*">404 - not found</Route>
-            </Switch>
-          </PageContainer>
+          <Provider store={store}>
+            <PageContainer>
+              <Header />
+              <Switch>
+                <Route path={'/'} exact>
+                  <Index />
+                </Route>
+                <Route path={['/authError']} exact>
+                  <div>Autentikaatio epäonnistui</div>
+                </Route>
+                <Route path={['/logout']} exact>
+                  <LogOut />
+                </Route>
+                <Route path={['/oikaisuvaatimus']} exact>
+                  <ParkingFineAppeal />
+                </Route>
+                <Route path={['/erapaivansiirto']} exact>
+                  <ExtendDueDate />
+                </Route>
+                <Route path="*">404 - not found</Route>
+              </Switch>
+            </PageContainer>
+          </Provider>
         </StoreProvider>
       </ClientProvider>
     </HandleCallback>

--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
-import FormStepper, { StepState } from '../formStepper/FormStepper';
+import FormStepper from '../formStepper/FormStepper';
+import { StepState } from '../formStepper/formStepperSlice';
 import { FormId, setSelectedForm } from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 

--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
 import FormStepper, { StepState } from '../formStepper/FormStepper';
+import { FormId, setSelectedForm } from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 
 const ExtendDueDate = (): React.ReactElement => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const steps = [
     {
       label: t('due-date:stepper:step1'),
@@ -17,11 +20,19 @@ const ExtendDueDate = (): React.ReactElement => {
     }
   ];
 
+  function handleSubmit() {
+    //console.log('submit extend due date form');
+  }
+
+  useEffect(() => {
+    dispatch(setSelectedForm(FormId.DUEDATE));
+  }, [dispatch]);
+
   return (
     <PageContent>
       <form>
         <h1 className={styles['form-title']}>{t('due-date:title')}</h1>
-        <FormStepper selectedForm="dueDate" initialSteps={steps} />
+        <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
       </form>
     </PageContent>
   );

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { formatISO } from 'date-fns';
 import {
   Button,
@@ -8,15 +9,23 @@ import {
   TextInput
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { setSubmitDisabled } from '../formContent/formContentSlice';
+import { selectedOption, setSelectedOption } from './extendDueDateFormSlice';
 import './ExtendDueDateForm.css';
 
 const ExtendDueDateForm = (): React.ReactElement => {
   const { t } = useTranslation();
-  const [selectedItem, setSelectedItem] = useState<number>();
+  const dispatch = useDispatch();
+  const selectedItem = useSelector(selectedOption);
   const [extensionAllowed, setExtensionAllowed] = useState(false);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
   // For testing the notifications
   const dueDate = formatISO(new Date('2022-11-20'), { representation: 'date' });
+
+  const handleItemChange = (value: number) => {
+    dispatch(setSelectedOption(value));
+    dispatch(setSubmitDisabled(value !== 1));
+  };
 
   useEffect(() => {
     const currentDate = formatISO(new Date(), { representation: 'date' });
@@ -88,7 +97,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
           label={t('due-date:radio-button:extend')}
           value="1"
           checked={selectedItem === 1}
-          onChange={() => setSelectedItem(1)}
+          onChange={() => handleItemChange(1)}
         />
         <RadioButton
           id="payRadio"
@@ -97,7 +106,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
           label={t('due-date:radio-button:pay')}
           value="2"
           checked={selectedItem === 2}
-          onChange={() => setSelectedItem(2)}
+          onChange={() => handleItemChange(2)}
         />
       </div>
       <Button

--- a/src/components/extendDueDate/extendDueDateFormSlice.tsx
+++ b/src/components/extendDueDate/extendDueDateFormSlice.tsx
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+type SliceState = {
+  selectedOption: number;
+};
+
+const initialState: SliceState = {
+  selectedOption: 0
+};
+
+export const slice = createSlice({
+  name: 'extendDueDateForm',
+  initialState,
+  reducers: {
+    setSelectedOption: (state, action) => {
+      state.selectedOption = action.payload;
+    }
+  }
+});
+
+// Actions
+export const { setSelectedOption } = slice.actions;
+
+// Selectors
+export const selectedOption = (state: RootState) =>
+  state.extendDueDateForm.selectedOption;
+
+export default slice.reducer;

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import SearchForm from '../searchForm/SearchForm';
 import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
+import { FormId, selectFormContent } from './formContentSlice';
 import './FormContent.css';
 
 interface Props {
-  selectedForm: string;
   activeStep: number;
 }
 
-const FormContent = (props: Props): React.ReactElement => (
-  <div className="form-container">
-    {props.activeStep === 0 && <SearchForm />}
-    {props.activeStep === 1 && props.selectedForm === 'dueDate' && (
-      <ExtendDueDateForm />
-    )}
-  </div>
-);
+const FormContent = (props: Props): React.ReactElement => {
+  const formContent = useSelector(selectFormContent);
+  return (
+    <div className="form-container">
+      {props.activeStep === 0 && <SearchForm />}
+      {props.activeStep === 1 &&
+        formContent.selectedForm === FormId.DUEDATE && <ExtendDueDateForm />}
+    </div>
+  );
+};
 
 export default FormContent;

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+export enum FormId {
+  NONE = '',
+  DUEDATE = 'dueDate',
+  PARKINGFINE = 'parkingFine',
+  MOVEDCAR = 'movedCar'
+}
+
+type SliceState = {
+  selectedForm: FormId;
+  submitDisabled: boolean;
+};
+
+const initialState: SliceState = {
+  selectedForm: FormId.NONE,
+  submitDisabled: true
+};
+
+export const slice = createSlice({
+  name: 'formContent',
+  initialState,
+  reducers: {
+    setSelectedForm: (state, action) => {
+      state.selectedForm = action.payload;
+    },
+    setSubmitDisabled: (state, action) => {
+      state.submitDisabled = action.payload;
+    }
+  }
+});
+
+// Actions
+export const { setSelectedForm, setSubmitDisabled } = slice.actions;
+
+// Selectors
+export const selectFormContent = (state: RootState) => state.formContent;
+
+export default slice.reducer;

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -8,8 +8,7 @@ import {
   selectStepperState,
   completeStep,
   setActive,
-  setSteps,
-  setNumberOfSteps
+  setSteps
 } from './formStepperSlice';
 import { selectFormContent } from '../formContent/formContentSlice';
 import './FormStepper.css';
@@ -22,13 +21,12 @@ interface Props {
 const FormStepper = (props: Props): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const stepperState = useSelector(selectStepperState);
+  const { activeStepIndex, steps } = useSelector(selectStepperState);
   const formContent = useSelector(selectFormContent);
-  const lastStep = stepperState.activeStepIndex === stepperState.stepsTotal - 1;
+  const lastStep = activeStepIndex === steps.length - 1;
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));
-    dispatch(setNumberOfSteps(props.initialSteps.length));
   }, [dispatch, props.initialSteps]);
 
   return (
@@ -36,24 +34,24 @@ const FormStepper = (props: Props): React.ReactElement => {
       <Stepper
         language="fi"
         onStepClick={(event, stepIndex) => dispatch(setActive(stepIndex))}
-        selectedStep={stepperState.activeStepIndex}
+        selectedStep={activeStepIndex}
         stepHeading
-        steps={stepperState.steps}
+        steps={steps}
       />
-      <FormContent activeStep={stepperState.activeStepIndex} />
+      <FormContent activeStep={activeStepIndex} />
       <div
         className={lastStep ? 'button-container-submit' : 'button-container'}>
         <Button
-          disabled={stepperState.activeStepIndex === 0}
+          disabled={activeStepIndex === 0}
           iconLeft={<IconArrowLeft />}
-          onClick={() => dispatch(setActive(stepperState.activeStepIndex - 1))}
+          onClick={() => dispatch(setActive(activeStepIndex - 1))}
           variant="secondary">
           {t('common:previous')}
         </Button>
         {!lastStep ? (
           <Button
             iconRight={<IconArrowRight />}
-            onClick={() => dispatch(completeStep(stepperState.activeStepIndex))}
+            onClick={() => dispatch(completeStep(activeStepIndex))}
             variant="primary">
             {t('common:next')}
           </Button>

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -1,12 +1,14 @@
 import React, { useReducer } from 'react';
+import { useSelector } from 'react-redux';
 import { Button, IconArrowLeft, IconArrowRight, Stepper } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import FormContent from '../formContent/FormContent';
+import { selectFormContent } from '../formContent/formContentSlice';
 import './FormStepper.css';
 
 interface Props {
-  selectedForm: string;
   initialSteps: Step[];
+  onSubmit: () => void;
 }
 
 type Step = {
@@ -32,6 +34,7 @@ export enum StepState {
 
 const FormStepper = (props: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const formContent = useSelector(selectFormContent);
 
   const commonReducer = (stepsTotal: number) => (
     state: StepperState,
@@ -102,10 +105,7 @@ const FormStepper = (props: Props): React.ReactElement => {
         stepHeading
         steps={state.steps}
       />
-      <FormContent
-        selectedForm={props.selectedForm}
-        activeStep={state.activeStepIndex}
-      />
+      <FormContent activeStep={state.activeStepIndex} />
       <div
         className={lastStep ? 'button-container-submit' : 'button-container'}>
         <Button
@@ -124,19 +124,21 @@ const FormStepper = (props: Props): React.ReactElement => {
           <Button
             iconRight={<IconArrowRight />}
             onClick={() =>
-              dispatch({ type: 'completeStep', payload: state.activeStepIndex })
+              dispatch({
+                type: 'completeStep',
+                payload: state.activeStepIndex
+              })
             }
-            variant={'primary'}>
+            variant="primary">
             {t('common:next')}
           </Button>
         ) : (
           <Button
             className="submit-button"
-            onClick={() =>
-              dispatch({ type: 'completeStep', payload: state.activeStepIndex })
-            }
-            variant={'primary'}>
-            {props.selectedForm === 'dueDate'
+            onClick={() => props.onSubmit()}
+            variant="primary"
+            disabled={formContent.submitDisabled}>
+            {formContent.selectedForm === 'dueDate'
               ? t('due-date:submit')
               : t('common:send')}
           </Button>

--- a/src/components/formStepper/formStepperSlice.tsx
+++ b/src/components/formStepper/formStepperSlice.tsx
@@ -1,0 +1,91 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+export enum StepState {
+  available,
+  completed,
+  disabled
+}
+
+export type Step = {
+  label: string;
+  state: number;
+};
+
+type SliceState = {
+  activeStepIndex: number;
+  steps: Step[];
+  stepsTotal: number;
+};
+
+const initialState: SliceState = {
+  activeStepIndex: 0,
+  steps: [
+    {
+      label: '',
+      state: StepState.disabled
+    }
+  ],
+  stepsTotal: 0
+};
+
+export const slice = createSlice({
+  name: 'formStepper',
+  initialState,
+  reducers: {
+    setSteps: (state, action) => {
+      state.steps = action.payload;
+    },
+    setNumberOfSteps: (state, action) => {
+      state.stepsTotal = action.payload;
+    },
+    completeStep: (state, action) => {
+      state.activeStepIndex =
+        action.payload === state.stepsTotal - 1
+          ? state.stepsTotal - 1
+          : action.payload + 1;
+      state.steps = state.steps.map((step: Step, index: number) => {
+        if (index === action.payload && index !== state.stepsTotal - 1) {
+          // current one but not last one
+          return {
+            state: StepState.completed,
+            label: step.label
+          };
+        }
+        if (index === action.payload + 1) {
+          // next one
+          return {
+            state: StepState.available,
+            label: step.label
+          };
+        }
+        return step;
+      });
+    },
+    setActive: (state, action) => {
+      state.activeStepIndex = action.payload;
+      state.steps = state.steps.map((step: Step, index: number) => {
+        if (index === action.payload) {
+          return {
+            state: StepState.available,
+            label: step.label
+          };
+        }
+        return step;
+      });
+    }
+  }
+});
+
+// Actions
+export const {
+  completeStep,
+  setActive,
+  setSteps,
+  setNumberOfSteps
+} = slice.actions;
+
+// Selectors
+export const selectStepperState = (state: RootState) => state.formStepper;
+
+export default slice.reducer;

--- a/src/components/formStepper/formStepperSlice.tsx
+++ b/src/components/formStepper/formStepperSlice.tsx
@@ -15,7 +15,6 @@ export type Step = {
 type SliceState = {
   activeStepIndex: number;
   steps: Step[];
-  stepsTotal: number;
 };
 
 const initialState: SliceState = {
@@ -25,8 +24,7 @@ const initialState: SliceState = {
       label: '',
       state: StepState.disabled
     }
-  ],
-  stepsTotal: 0
+  ]
 };
 
 export const slice = createSlice({
@@ -36,16 +34,12 @@ export const slice = createSlice({
     setSteps: (state, action) => {
       state.steps = action.payload;
     },
-    setNumberOfSteps: (state, action) => {
-      state.stepsTotal = action.payload;
-    },
     completeStep: (state, action) => {
+      const stepsTotal = state.steps.length;
       state.activeStepIndex =
-        action.payload === state.stepsTotal - 1
-          ? state.stepsTotal - 1
-          : action.payload + 1;
+        action.payload === stepsTotal - 1 ? stepsTotal - 1 : action.payload + 1;
       state.steps = state.steps.map((step: Step, index: number) => {
-        if (index === action.payload && index !== state.stepsTotal - 1) {
+        if (index === action.payload && index !== stepsTotal - 1) {
           // current one but not last one
           return {
             state: StepState.completed,
@@ -78,12 +72,7 @@ export const slice = createSlice({
 });
 
 // Actions
-export const {
-  completeStep,
-  setActive,
-  setSteps,
-  setNumberOfSteps
-} = slice.actions;
+export const { completeStep, setActive, setSteps } = slice.actions;
 
 // Selectors
 export const selectStepperState = (state: RootState) => state.formStepper;

--- a/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
+++ b/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
-import FormStepper, { StepState } from '../formStepper/FormStepper';
+import FormStepper from '../formStepper/FormStepper';
+import { StepState } from '../formStepper/formStepperSlice';
 import { FormId, setSelectedForm } from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 

--- a/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
+++ b/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
 import FormStepper, { StepState } from '../formStepper/FormStepper';
+import { FormId, setSelectedForm } from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 
 const ParkingFineAppeal = (): React.ReactElement => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const steps = [
     {
       label: t('parking-fine:stepper:step1'),
@@ -25,11 +28,19 @@ const ParkingFineAppeal = (): React.ReactElement => {
     }
   ];
 
+  function handleSubmit() {
+    //console.log('submit parking fine appeal form');
+  }
+
+  useEffect(() => {
+    dispatch(setSelectedForm(FormId.PARKINGFINE));
+  }, [dispatch]);
+
   return (
     <PageContent>
       <form>
         <h1 className={styles['form-title']}>{t('parking-fine:title')}</h1>
-        <FormStepper selectedForm="parkingFine" initialSteps={steps} />
+        <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
       </form>
     </PageContent>
   );

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import formContentReducer from './components/formContent/formContentSlice';
+import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
+
+const store = configureStore({
+  reducer: {
+    formContent: formContentReducer,
+    extendDueDateForm: extendDueDateFormReducer
+  }
+});
+
+export default store;
+export type RootState = ReturnType<typeof store.getState>;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import formContentReducer from './components/formContent/formContentSlice';
+import formStepperReducer from './components/formStepper/formStepperSlice';
 import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
 
 const store = configureStore({
   reducer: {
     formContent: formContentReducer,
+    formStepper: formStepperReducer,
     extendDueDateForm: extendDueDateFormReducer
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,6 +2521,16 @@
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.9.0.tgz#d834f3e6e2c992089192f3c83fb7963e3a6f5207"
   integrity sha512-YYksINfR6q92P10AhPEGo47Hd7oz1hrnZ6Vx8Gsrq62IbqDdv1XOTzPBaj17Z1ymNY2pitLUSEXsLmozt4wxxQ==
 
+"@reduxjs/toolkit@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.0.tgz#76b264fcea677d256b18f86cc77e00743a9e02b0"
+  integrity sha512-ak11IrjYcUXRqlhNPwnz6AcvA2ynJTu8PzDbbqQw4a3xR4KZtgiqbNblQD+10CRbfK4+5C79SOyxnT9dhBqFnA==
+  dependencies:
+    immer "^9.0.16"
+    redux "^4.2.0"
+    redux-thunk "^2.4.2"
+    reselect "^4.1.7"
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -6452,6 +6462,11 @@ immer@^4.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-4.0.2.tgz#9ff0fcdf88e06f92618a5978ceecb5884e633559"
   integrity sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w==
 
+immer@^9.0.16:
+  version "9.0.16"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.16.tgz#8e7caab80118c2b54b37ad43e05758cdefad0198"
+  integrity sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==
+
 immer@^9.0.7:
   version "9.0.15"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
@@ -9489,6 +9504,11 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.0.tgz#ac89e1d6b9bdb9ee49ce69a69071be41bbd82d67"
   integrity sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==
 
+redux-thunk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
+  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
+
 redux@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
@@ -9643,6 +9663,11 @@ reselect@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.1.tgz#7e2c110efbf3d70df3482604bcf2bc0ab571346a"
   integrity sha512-Jjt8Us6hAWJpjucyladHvUGR+q1mHHgWtGDXlhvvKyNyIeQ3bjuWLDX0bsTLhbm/gd4iXEACBlODUHBlLWiNnA==
+
+reselect@^4.1.7:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.7.tgz#56480d9ff3d3188970ee2b76527bd94a95567a42"
+  integrity sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR:
* Creates reducers that control the state of FormStepper, ExtendDueDateForm and FormContent
* Creates a global store for all the form-related reducers

In future, this store and the other store for client-related state in /client/redux/store.ts could probably be combined, especially since the client store uses deprecated createStore method.