### PR TITLE
Update due date extension form layout

### DIFF
--- a/src/components/extendDueDate/ExtendDueDateForm.css
+++ b/src/components/extendDueDate/ExtendDueDateForm.css
@@ -5,11 +5,10 @@
   margin-top: 24px;
 }
 
-.notification {
-  max-width: 384px;
+.barcode-container {
+  margin: 12px 0 24px;
 }
 
-.pay-button {
-  width: 332px;
-  margin-top: 24px;
+.checkbox {
+  margin-bottom: 12px;
 }

--- a/src/components/extendDueDate/ExtendDueDateForm.css
+++ b/src/components/extendDueDate/ExtendDueDateForm.css
@@ -9,6 +9,6 @@
   margin: 12px 0 24px;
 }
 
-.checkbox {
-  margin-bottom: 12px;
+.email-notification {
+  margin: 24px 0 12px;
 }

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -16,13 +16,16 @@ const ExtendDueDateForm = (): React.ReactElement => {
   const checkboxChecked = useSelector(emailConfirmationChecked);
   const [extensionAllowed, setExtensionAllowed] = useState(false);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
+  const [emailNotificationOpen, setEmailNotificationOpen] = useState(true);
   // For testing the notifications
   const dueDate = formatISO(new Date('2022-11-20'), { representation: 'date' });
 
   const handleCheckedChange = () => {
     dispatch(setEmailConfirmationChecked(!checkboxChecked));
+    setEmailNotificationOpen(true);
   };
 
+  // Allow extension only if due date has not passed
   useEffect(() => {
     const currentDate = formatISO(new Date(), { representation: 'date' });
     if (dueDate >= currentDate) {
@@ -100,13 +103,23 @@ const ExtendDueDateForm = (): React.ReactElement => {
         </Button>
       </div>
       <Checkbox
-        className="checkbox"
         label={t('common:email-confirmation')}
         id="emailConfirmationCheckbox"
         checked={checkboxChecked}
         onChange={handleCheckedChange}
         disabled={!extensionAllowed}
       />
+      {checkboxChecked && emailNotificationOpen && (
+        <Notification
+          className="email-notification"
+          size="small"
+          label={t('due-date:notifications:email-confirmation:label')}
+          dismissible
+          closeButtonLabelText="Close notification"
+          onClose={() => setEmailNotificationOpen(false)}>
+          {t('due-date:notifications:email-confirmation:text')}
+        </Notification>
+      )}
     </div>
   );
 };

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -1,43 +1,54 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { formatISO } from 'date-fns';
-import {
-  Button,
-  IconLinkExternal,
-  Notification,
-  RadioButton,
-  TextInput
-} from 'hds-react';
+import { Button, Checkbox, IconCopy, Notification, TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { setSubmitDisabled } from '../formContent/formContentSlice';
-import { selectedOption, setSelectedOption } from './extendDueDateFormSlice';
+import {
+  emailConfirmationChecked,
+  setEmailConfirmationChecked
+} from './extendDueDateFormSlice';
 import './ExtendDueDateForm.css';
+import { setSubmitDisabled } from '../formContent/formContentSlice';
 
 const ExtendDueDateForm = (): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const selectedItem = useSelector(selectedOption);
+  const checkboxChecked = useSelector(emailConfirmationChecked);
   const [extensionAllowed, setExtensionAllowed] = useState(false);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
   // For testing the notifications
   const dueDate = formatISO(new Date('2022-11-20'), { representation: 'date' });
 
-  const handleItemChange = (value: number) => {
-    dispatch(setSelectedOption(value));
-    dispatch(setSubmitDisabled(value !== 1));
+  const handleCheckedChange = () => {
+    dispatch(setEmailConfirmationChecked(!checkboxChecked));
   };
 
   useEffect(() => {
     const currentDate = formatISO(new Date(), { representation: 'date' });
     if (dueDate >= currentDate) {
       setExtensionAllowed(true);
+      dispatch(setSubmitDisabled(false));
     }
     setInfoNotificationOpen(true);
-  }, [dueDate]);
+  }, [dispatch, dueDate]);
 
   return (
     <div>
       <p>{t('common:required-fields')}</p>
+      {infoNotificationOpen && (
+        <Notification
+          label={
+            extensionAllowed
+              ? t('due-date:notifications:allowed:label')
+              : t('due-date:notifications:not-allowed:label')
+          }
+          type={extensionAllowed ? 'success' : 'error'}
+          dismissible
+          closeButtonLabelText="Close notification"
+          onClose={() => setInfoNotificationOpen(false)}>
+          {t('due-date:notifications:allowed:text')}
+        </Notification>
+      )}
       <div className="info-container">
         <TextInput
           id="refNumber"
@@ -73,50 +84,29 @@ const ExtendDueDateForm = (): React.ReactElement => {
           />
         )}
       </div>
-      {infoNotificationOpen && (
-        <Notification
-          className="notification"
-          label={
-            extensionAllowed
-              ? t('due-date:notifications:allowed:label')
-              : t('due-date:notifications:not-allowed:label')
-          }
-          type={extensionAllowed ? 'success' : 'error'}
-          dismissible
-          closeButtonLabelText="Close notification"
-          onClose={() => setInfoNotificationOpen(false)}>
-          {t('due-date:notifications:allowed:text')}
-        </Notification>
-      )}
-      <div>
-        <p>{t('common:selection')}</p>
-        <RadioButton
-          id="extendRadio"
-          name="extendRadio"
-          disabled={!extensionAllowed}
-          label={t('due-date:radio-button:extend')}
-          value="1"
-          checked={selectedItem === 1}
-          onChange={() => handleItemChange(1)}
+      <div className="barcode-container">
+        <TextInput
+          id="barCode"
+          label={t('common:fine-info:barcode:label')}
+          defaultValue="43012383000123056001240000000000000000018714210302"
+          readOnly
         />
-        <RadioButton
-          id="payRadio"
-          name="payRadio"
-          disabled={!extensionAllowed}
-          label={t('due-date:radio-button:pay')}
-          value="2"
-          checked={selectedItem === 2}
-          onChange={() => handleItemChange(2)}
-        />
+        <Button
+          className="barcode-button"
+          iconLeft={<IconCopy />}
+          //onClick={}
+          variant="secondary">
+          {t('common:copy-barcode')}
+        </Button>
       </div>
-      <Button
-        className="pay-button"
-        disabled={selectedItem !== 2}
-        iconRight={<IconLinkExternal />}
-        //onClick={}
-        variant="secondary">
-        {t('common:pay')}
-      </Button>
+      <Checkbox
+        className="checkbox"
+        label={t('common:email-confirmation')}
+        id="emailConfirmationCheckbox"
+        checked={checkboxChecked}
+        onChange={handleCheckedChange}
+        disabled={!extensionAllowed}
+      />
     </div>
   );
 };

--- a/src/components/extendDueDate/extendDueDateFormSlice.tsx
+++ b/src/components/extendDueDate/extendDueDateFormSlice.tsx
@@ -2,28 +2,28 @@ import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../../store';
 
 type SliceState = {
-  selectedOption: number;
+  emailConfirmationChecked: boolean;
 };
 
 const initialState: SliceState = {
-  selectedOption: 0
+  emailConfirmationChecked: false
 };
 
 export const slice = createSlice({
   name: 'extendDueDateForm',
   initialState,
   reducers: {
-    setSelectedOption: (state, action) => {
-      state.selectedOption = action.payload;
+    setEmailConfirmationChecked: (state, action) => {
+      state.emailConfirmationChecked = action.payload;
     }
   }
 });
 
 // Actions
-export const { setSelectedOption } = slice.actions;
+export const { setEmailConfirmationChecked } = slice.actions;
 
 // Selectors
-export const selectedOption = (state: RootState) =>
-  state.extendDueDateForm.selectedOption;
+export const emailConfirmationChecked = (state: RootState) =>
+  state.extendDueDateForm.emailConfirmationChecked;
 
 export default slice.reducer;

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -98,11 +98,15 @@
         "text": "Eräpäivän siirto on mahdollista vain, jos pysäköintivirhemaksun eräpäivä ei ole mennyt umpeen."
       },
       "not-allowed": {
-        "label": "Et voi enää siirtää eräpäivää"
+        "label": "Et voi siirtää eräpäivää"
+      },
+      "email-confirmation": {
+        "label": "Saat vahvistuksen sähköpostilla",
+        "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: etunimi@sukunimi.fi."
       },
       "success": {
         "label": "Eräpäivää on siirretty",
-        "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on x.x.xxxx ."
+        "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on x.x.xxxx."
       }
     },
     "radio-button": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -109,10 +109,6 @@
         "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on x.x.xxxx."
       }
     },
-    "radio-button": {
-      "extend": "Siirtää eräpäivää 30 päivällä",
-      "pay": "Maksaa pysäköintivirhemaksun"
-    },
     "submit": "Siirrä eräpäivää"
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -3,10 +3,9 @@
     "previous": "Edellinen",
     "next": "Seuraava",
     "send": "Lähetä",
-    "pay": "Maksamaan",
-    "selection": "Haluan *",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "copy-barcode": "Kopioi virtuaaliviivakoodi",
+    "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "fine-info": {
       "ref-number": {
         "label": "Asianumero",


### PR DESCRIPTION
This PR updates the due date extension form based on updated designs.

![Screenshot 2022-11-15 at 15 34 40](https://user-images.githubusercontent.com/36920208/201933900-f4140cd1-4ed4-4f9e-95f4-d3dee3c9f2ad.png)


Missing:
- Submit button logic
- Copying to clipboard handler from barcode
- Dynamic information (email address and new due date) from notifications
- Link to Helsinki profile from email confirmation notification
- Mobile styling