### PR TITLE
Add dynamic info to notifications on extend due date form

### DIFF
--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -4,7 +4,11 @@ import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
 import FormStepper from '../formStepper/FormStepper';
 import { StepState } from '../formStepper/formStepperSlice';
-import { FormId, setSelectedForm } from '../formContent/formContentSlice';
+import {
+  FormId,
+  setFormSubmitted,
+  setSelectedForm
+} from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 
 const ExtendDueDate = (): React.ReactElement => {
@@ -22,7 +26,7 @@ const ExtendDueDate = (): React.ReactElement => {
   ];
 
   function handleSubmit() {
-    //console.log('submit extend due date form');
+    dispatch(setFormSubmitted(true));
   }
 
   useEffect(() => {

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { useClient } from '../../client/hooks';
 import {
   emailConfirmationChecked,
   setEmailConfirmationChecked
@@ -20,6 +21,8 @@ import { setSubmitDisabled } from '../formContent/formContentSlice';
 const ExtendDueDateForm = (): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const { getUser } = useClient();
+  const user = getUser();
   const checkboxChecked = useSelector(emailConfirmationChecked);
   const [extensionAllowed, setExtensionAllowed] = useState(false);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
@@ -124,7 +127,9 @@ const ExtendDueDateForm = (): React.ReactElement => {
           dismissible
           closeButtonLabelText="Close notification"
           onClose={() => setEmailNotificationOpen(false)}>
-          {t('due-date:notifications:email-confirmation:text')}
+          {t('due-date:notifications:email-confirmation:text', {
+            email: user?.email
+          })}
           <Link
             href={window._env_.REACT_APP_PROFILE_UI_URL}
             size="S"

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { formatISO } from 'date-fns';
 import {
   Button,
   Checkbox,
@@ -11,6 +10,11 @@ import {
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useClient } from '../../client/hooks';
+import {
+  formatDate,
+  getNewDueDate,
+  isExtensionAllowed
+} from '../../utils/helpers';
 import {
   emailConfirmationChecked,
   setEmailConfirmationChecked
@@ -24,11 +28,13 @@ const ExtendDueDateForm = (): React.ReactElement => {
   const { getUser } = useClient();
   const user = getUser();
   const checkboxChecked = useSelector(emailConfirmationChecked);
-  const [extensionAllowed, setExtensionAllowed] = useState(false);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
   const [emailNotificationOpen, setEmailNotificationOpen] = useState(true);
   // For testing the notifications
-  const dueDate = formatISO(new Date('2022-11-20'), { representation: 'date' });
+  const dueDateObject = new Date('2022-12-12');
+  const extensionAllowed = isExtensionAllowed(dueDateObject);
+  const dueDate = formatDate(dueDateObject);
+  const newDueDate = getNewDueDate(dueDateObject);
 
   const handleCheckedChange = () => {
     dispatch(setEmailConfirmationChecked(!checkboxChecked));
@@ -37,13 +43,11 @@ const ExtendDueDateForm = (): React.ReactElement => {
 
   // Allow extension only if due date has not passed
   useEffect(() => {
-    const currentDate = formatISO(new Date(), { representation: 'date' });
-    if (dueDate >= currentDate) {
-      setExtensionAllowed(true);
+    if (extensionAllowed) {
       dispatch(setSubmitDisabled(false));
     }
     setInfoNotificationOpen(true);
-  }, [dispatch, dueDate]);
+  }, [dispatch, extensionAllowed]);
 
   return (
     <div>
@@ -85,14 +89,14 @@ const ExtendDueDateForm = (): React.ReactElement => {
         <TextInput
           id="dueDate"
           label={t('common:fine-info:due-date:label')}
-          defaultValue="20.11.2022"
+          value={dueDate}
           readOnly
         />
         {extensionAllowed && (
           <TextInput
             id="newDueDate"
             label={t('due-date:new-due-date')}
-            defaultValue="20.12.2022"
+            value={newDueDate}
             readOnly
           />
         )}

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -10,34 +10,34 @@ import {
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useClient } from '../../client/hooks';
+import { formatDate, isExtensionAllowed } from '../../utils/helpers';
 import {
-  formatDate,
-  getNewDueDate,
-  isExtensionAllowed
-} from '../../utils/helpers';
-import {
-  emailConfirmationChecked,
+  selectDueDateFormValues,
   setEmailConfirmationChecked
 } from './extendDueDateFormSlice';
 import './ExtendDueDateForm.css';
-import { setSubmitDisabled } from '../formContent/formContentSlice';
+import {
+  selectFormContent,
+  setSubmitDisabled
+} from '../formContent/formContentSlice';
 
 const ExtendDueDateForm = (): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { getUser } = useClient();
   const user = getUser();
-  const checkboxChecked = useSelector(emailConfirmationChecked);
+  const formContent = useSelector(selectFormContent);
+  const dueDateFormValues = useSelector(selectDueDateFormValues);
+  const dueDate = formatDate(dueDateFormValues.dueDate);
+  const newDueDate = formatDate(dueDateFormValues.newDueDate);
+  const extensionAllowed = isExtensionAllowed(dueDateFormValues.dueDate);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
   const [emailNotificationOpen, setEmailNotificationOpen] = useState(true);
-  // For testing the notifications
-  const dueDateObject = new Date('2022-12-12');
-  const extensionAllowed = isExtensionAllowed(dueDateObject);
-  const dueDate = formatDate(dueDateObject);
-  const newDueDate = getNewDueDate(dueDateObject);
 
   const handleCheckedChange = () => {
-    dispatch(setEmailConfirmationChecked(!checkboxChecked));
+    dispatch(
+      setEmailConfirmationChecked(!dueDateFormValues.emailConfirmationChecked)
+    );
     setEmailNotificationOpen(true);
   };
 
@@ -119,11 +119,11 @@ const ExtendDueDateForm = (): React.ReactElement => {
       <Checkbox
         label={t('common:email-confirmation')}
         id="emailConfirmationCheckbox"
-        checked={checkboxChecked}
+        checked={dueDateFormValues.emailConfirmationChecked}
         onChange={handleCheckedChange}
-        disabled={!extensionAllowed}
+        disabled={!extensionAllowed || formContent.formSubmitted}
       />
-      {checkboxChecked && emailNotificationOpen && (
+      {dueDateFormValues.emailConfirmationChecked && emailNotificationOpen && (
         <Notification
           className="email-notification"
           size="small"

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { formatISO } from 'date-fns';
-import { Button, Checkbox, IconCopy, Notification, TextInput } from 'hds-react';
+import {
+  Button,
+  Checkbox,
+  IconCopy,
+  Link,
+  Notification,
+  TextInput
+} from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import {
   emailConfirmationChecked,
@@ -118,6 +125,15 @@ const ExtendDueDateForm = (): React.ReactElement => {
           closeButtonLabelText="Close notification"
           onClose={() => setEmailNotificationOpen(false)}>
           {t('due-date:notifications:email-confirmation:text')}
+          <Link
+            href={window._env_.REACT_APP_PROFILE_UI_URL}
+            size="S"
+            external
+            openInNewTab
+            openInExternalDomainAriaLabel="Opens a different website"
+            openInNewTabAriaLabel="Opens in a new tab.">
+            {t('common:helsinki-profile-link')}
+          </Link>
         </Notification>
       )}
     </div>

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -130,8 +130,8 @@ const ExtendDueDateForm = (): React.ReactElement => {
             size="S"
             external
             openInNewTab
-            openInExternalDomainAriaLabel="Opens a different website"
-            openInNewTabAriaLabel="Opens in a new tab.">
+            openInExternalDomainAriaLabel={t('common:aria:open-external')}
+            openInNewTabAriaLabel={t('common:aria:open-new-tab')}>
             {t('common:helsinki-profile-link')}
           </Link>
         </Notification>

--- a/src/components/extendDueDate/extendDueDateFormSlice.tsx
+++ b/src/components/extendDueDate/extendDueDateFormSlice.tsx
@@ -2,10 +2,15 @@ import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../../store';
 
 type SliceState = {
+  dueDate: string;
+  newDueDate: string;
   emailConfirmationChecked: boolean;
 };
 
 const initialState: SliceState = {
+  // for testing the notifications
+  dueDate: '2022-12-12',
+  newDueDate: '2023-01-11',
   emailConfirmationChecked: false
 };
 
@@ -23,7 +28,7 @@ export const slice = createSlice({
 export const { setEmailConfirmationChecked } = slice.actions;
 
 // Selectors
-export const emailConfirmationChecked = (state: RootState) =>
-  state.extendDueDateForm.emailConfirmationChecked;
+export const selectDueDateFormValues = (state: RootState) =>
+  state.extendDueDateForm;
 
 export default slice.reducer;

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -9,11 +9,13 @@ export enum FormId {
 }
 
 type SliceState = {
+  formSubmitted: boolean;
   selectedForm: FormId;
   submitDisabled: boolean;
 };
 
 const initialState: SliceState = {
+  formSubmitted: false,
   selectedForm: FormId.NONE,
   submitDisabled: true
 };
@@ -22,6 +24,9 @@ export const slice = createSlice({
   name: 'formContent',
   initialState,
   reducers: {
+    setFormSubmitted: (state, action) => {
+      state.formSubmitted = action.payload;
+    },
     setSelectedForm: (state, action) => {
       state.selectedForm = action.payload;
     },
@@ -32,7 +37,11 @@ export const slice = createSlice({
 });
 
 // Actions
-export const { setSelectedForm, setSubmitDisabled } = slice.actions;
+export const {
+  setFormSubmitted,
+  setSelectedForm,
+  setSubmitDisabled
+} = slice.actions;
 
 // Selectors
 export const selectFormContent = (state: RootState) => state.formContent;

--- a/src/components/formStepper/FormStepper.css
+++ b/src/components/formStepper/FormStepper.css
@@ -2,7 +2,7 @@
   align-items: flex-start;
   display: flex;
   gap: 24px;
-  height: 100px;
+  height: 96px;
   justify-content: flex-start;
   margin-top: 12px;
 }
@@ -11,11 +11,15 @@
   align-items: flex-start;
   display: flex;
   gap: 24px;
-  height: 100px;
+  height: 96px;
   justify-content: space-between;
   margin-top: 12px;
 }
 
 .submit-button {
   min-width: 137px;
+}
+
+.submit-notification {
+  margin-bottom: 24px;
 }

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -1,7 +1,14 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Button, IconArrowLeft, IconArrowRight, Stepper } from 'hds-react';
+import {
+  Button,
+  IconArrowLeft,
+  IconArrowRight,
+  Notification,
+  Stepper
+} from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { formatDate } from '../../utils/helpers';
 import FormContent from '../formContent/FormContent';
 import {
   Step,
@@ -10,7 +17,8 @@ import {
   setActive,
   setSteps
 } from './formStepperSlice';
-import { selectFormContent } from '../formContent/formContentSlice';
+import { FormId, selectFormContent } from '../formContent/formContentSlice';
+import { selectDueDateFormValues } from '../extendDueDate/extendDueDateFormSlice';
 import './FormStepper.css';
 
 interface Props {
@@ -23,7 +31,9 @@ const FormStepper = (props: Props): React.ReactElement => {
   const dispatch = useDispatch();
   const { activeStepIndex, steps } = useSelector(selectStepperState);
   const formContent = useSelector(selectFormContent);
+  const dueDateFormValues = useSelector(selectDueDateFormValues);
   const lastStep = activeStepIndex === steps.length - 1;
+  const [submitNotificationOpen, setSubmitNotificationOpen] = useState(true);
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));
@@ -67,6 +77,22 @@ const FormStepper = (props: Props): React.ReactElement => {
           </Button>
         )}
       </div>
+      {formContent.formSubmitted && submitNotificationOpen && (
+        <Notification
+          label={
+            formContent.selectedForm == FormId.DUEDATE &&
+            t('due-date:notifications:success:label')
+          }
+          type={'success'}
+          dismissible
+          closeButtonLabelText="Close notification"
+          onClose={() => setSubmitNotificationOpen(false)}>
+          {formContent.selectedForm == FormId.DUEDATE &&
+            t('due-date:notifications:success:text', {
+              newDueDate: formatDate(dueDateFormValues.newDueDate)
+            })}
+        </Notification>
+      )}
     </div>
   );
 };

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -35,6 +35,11 @@ const FormStepper = (props: Props): React.ReactElement => {
   const lastStep = activeStepIndex === steps.length - 1;
   const [submitNotificationOpen, setSubmitNotificationOpen] = useState(true);
 
+  const handleSubmit = () => {
+    setSubmitNotificationOpen(true);
+    props.onSubmit();
+  };
+
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));
   }, [dispatch, props.initialSteps]);
@@ -68,7 +73,7 @@ const FormStepper = (props: Props): React.ReactElement => {
         ) : (
           <Button
             className="submit-button"
-            onClick={() => props.onSubmit()}
+            onClick={handleSubmit}
             variant="primary"
             disabled={formContent.submitDisabled}>
             {formContent.selectedForm === 'dueDate'
@@ -77,8 +82,9 @@ const FormStepper = (props: Props): React.ReactElement => {
           </Button>
         )}
       </div>
-      {formContent.formSubmitted && submitNotificationOpen && (
+      {lastStep && formContent.formSubmitted && submitNotificationOpen && (
         <Notification
+          className="submit-notification"
           label={
             formContent.selectedForm == FormId.DUEDATE &&
             t('due-date:notifications:success:label')

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -6,6 +6,7 @@
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "copy-barcode": "Kopioi virtuaaliviivakoodi",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
+    "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",
     "fine-info": {
       "ref-number": {
         "label": "Asianumero",
@@ -102,7 +103,7 @@
       },
       "email-confirmation": {
         "label": "Saat vahvistuksen sähköpostilla",
-        "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: etunimi@sukunimi.fi."
+        "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: etunimi@sukunimi.fi. "
       },
       "success": {
         "label": "Eräpäivää on siirretty",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -111,7 +111,7 @@
       },
       "success": {
         "label": "Eräpäivää on siirretty",
-        "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on x.x.xxxx."
+        "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on {{newDueDate}}."
       }
     },
     "submit": "Siirrä eräpäivää"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -7,6 +7,10 @@
     "copy-barcode": "Kopioi virtuaaliviivakoodi",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",
+    "aria": {
+      "open-external": "Avaa toisen verkkosivun.",
+      "open-new-tab": "Avautuu uudessa välilehdessä."
+    },
     "fine-info": {
       "ref-number": {
         "label": "Asianumero",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -107,7 +107,7 @@
       },
       "email-confirmation": {
         "label": "Saat vahvistuksen sähköpostilla",
-        "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: etunimi@sukunimi.fi. "
+        "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: {{email}}. "
       },
       "success": {
         "label": "Eräpäivää on siirretty",

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,26 @@
+import { addDays, format, formatISO } from 'date-fns';
+
+const EXTENDEDDAYS = 30;
+
+export function formatDate(date: Date): string {
+  return format(date, 'dd.MM.yyyy');
+}
+
+// add 30 days to the original date and return the new date
+export function getNewDueDate(date: Date): string {
+  return formatDate(addDays(date, EXTENDEDDAYS));
+}
+
+// check if date is the present day or in future
+function isInFuture(date: Date): boolean {
+  // compare only dates and not times
+  const currentDate = formatISO(new Date(), { representation: 'date' });
+  const comparedDate = formatISO(date, { representation: 'date' });
+  return comparedDate >= currentDate;
+}
+
+// in future there will be multiple possible reasons why extending
+// due date is not allowed
+export function isExtensionAllowed(date: Date): boolean {
+  return isInFuture(date);
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,25 +2,26 @@ import { addDays, format, formatISO } from 'date-fns';
 
 const EXTENDEDDAYS = 30;
 
-export function formatDate(date: Date): string {
-  return format(date, 'dd.MM.yyyy');
+// from 'yyyy-mm-dd' to 'dd.mm.yyyy'
+export function formatDate(date: string | Date): string {
+  return format(new Date(date), 'dd.MM.yyyy');
 }
 
 // add 30 days to the original date and return the new date
-export function getNewDueDate(date: Date): string {
-  return formatDate(addDays(date, EXTENDEDDAYS));
+export function getNewDueDate(date: string): string {
+  return formatDate(addDays(new Date(date), EXTENDEDDAYS));
 }
 
 // check if date is the present day or in future
-function isInFuture(date: Date): boolean {
+function isInFuture(date: string): boolean {
   // compare only dates and not times
   const currentDate = formatISO(new Date(), { representation: 'date' });
-  const comparedDate = formatISO(date, { representation: 'date' });
+  const comparedDate = formatISO(new Date(date), { representation: 'date' });
   return comparedDate >= currentDate;
 }
 
 // in future there will be multiple possible reasons why extending
 // due date is not allowed
-export function isExtensionAllowed(date: Date): boolean {
+export function isExtensionAllowed(date: string): boolean {
   return isInFuture(date);
 }


### PR DESCRIPTION
This PR adds:
* Dynamic info (email, new due date, link to helsinki profile) to notifications on extend due date form
* "Form submitted" notification to extend due date form
* Some helper functions for date formatting

![Screenshot 2022-11-17 at 11 40 38](https://user-images.githubusercontent.com/36920208/202411288-5a7ea1be-5faa-4c22-9915-4a2a34e8203e.png)

Still missing from extend due date form, not on scope of this PR:
* Button to go back on the main page
* Changing the submit button styling when form is submitted