### PR TITLE
Add submit button styling

### DIFF
--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -4,11 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PageContent from '../PageContent';
 import FormStepper from '../formStepper/FormStepper';
 import { StepState } from '../formStepper/formStepperSlice';
-import {
-  FormId,
-  setFormSubmitted,
-  setSelectedForm
-} from '../formContent/formContentSlice';
+import { FormId, setSelectedForm } from '../formContent/formContentSlice';
 import styles from '../styles.module.css';
 
 const ExtendDueDate = (): React.ReactElement => {
@@ -26,7 +22,7 @@ const ExtendDueDate = (): React.ReactElement => {
   ];
 
   function handleSubmit() {
-    dispatch(setFormSubmitted(true));
+    //dispatch(setFormSubmitted(true));
   }
 
   useEffect(() => {

--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -21,9 +21,9 @@ const ExtendDueDate = (): React.ReactElement => {
     }
   ];
 
-  function handleSubmit() {
-    //dispatch(setFormSubmitted(true));
-  }
+  const handleSubmit = () => {
+    //console.log('submit extend due date form');
+  };
 
   useEffect(() => {
     dispatch(setSelectedForm(FormId.DUEDATE));

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -95,7 +95,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
         {extensionAllowed && (
           <TextInput
             id="newDueDate"
-            label={t('due-date:new-due-date')}
+            label={t('dueDate:new-due-date')}
             value={newDueDate}
             readOnly
           />
@@ -127,11 +127,11 @@ const ExtendDueDateForm = (): React.ReactElement => {
         <Notification
           className="email-notification"
           size="small"
-          label={t('due-date:notifications:email-confirmation:label')}
+          label={t('dueDate:notifications:email-confirmation:label')}
           dismissible
           closeButtonLabelText="Close notification"
           onClose={() => setEmailNotificationOpen(false)}>
-          {t('due-date:notifications:email-confirmation:text', {
+          {t('dueDate:notifications:email-confirmation:text', {
             email: user?.email
           })}
           <Link

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -95,7 +95,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
         {extensionAllowed && (
           <TextInput
             id="newDueDate"
-            label={t('dueDate:new-due-date')}
+            label={t('due-date:new-due-date')}
             value={newDueDate}
             readOnly
           />
@@ -127,11 +127,11 @@ const ExtendDueDateForm = (): React.ReactElement => {
         <Notification
           className="email-notification"
           size="small"
-          label={t('dueDate:notifications:email-confirmation:label')}
+          label={t('due-date:notifications:email-confirmation:label')}
           dismissible
           closeButtonLabelText="Close notification"
           onClose={() => setEmailNotificationOpen(false)}>
-          {t('dueDate:notifications:email-confirmation:text', {
+          {t('due-date:notifications:email-confirmation:text', {
             email: user?.email
           })}
           <Link

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -15,9 +15,9 @@ const FormContent = (props: Props): React.ReactElement => {
 
   const selectForm = (selectedForm: FormId) => {
     switch (selectedForm) {
-      case 'dueDate':
+      case 'due-date':
         return <ExtendDueDateForm />;
-      case 'parkingFine':
+      case 'parking-fine':
         return <ParkingFineSummary />;
     }
   };

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -3,9 +3,9 @@ import { RootState } from '../../store';
 
 export enum FormId {
   NONE = '',
-  DUEDATE = 'dueDate',
-  PARKINGFINE = 'parkingFine',
-  MOVEDCAR = 'movedCar'
+  DUEDATE = 'due-date',
+  PARKINGFINE = 'parking-fine',
+  MOVEDCAR = 'moved-car'
 }
 
 type SliceState = {

--- a/src/components/formStepper/FormStepper.css
+++ b/src/components/formStepper/FormStepper.css
@@ -23,3 +23,7 @@
 .submit-notification {
   margin-bottom: 24px;
 }
+
+.wide-button {
+  width: 100%;
+}

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Button,
@@ -37,16 +37,22 @@ const FormStepper = (props: Props): React.ReactElement => {
   const formContent = useSelector(selectFormContent);
   const dueDateFormValues = useSelector(selectDueDateFormValues);
   const lastStep = activeStepIndex === steps.length - 1;
-  const [submitNotificationOpen, setSubmitNotificationOpen] = useState(true);
+  const [showSubmitNotification, setShowSubmitNotification] = useState(false);
+  const mainPageButtonRef = useRef<null | HTMLDivElement>(null);
 
   function handleSubmit() {
-    setSubmitNotificationOpen(true);
     dispatch(setFormSubmitted(true));
+    setShowSubmitNotification(true);
   }
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));
   }, [dispatch, props.initialSteps]);
+
+  // scroll down to ensure submit notification and button to main page are visible
+  useEffect(() => {
+    mainPageButtonRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [showSubmitNotification]);
 
   return (
     <div>
@@ -93,25 +99,27 @@ const FormStepper = (props: Props): React.ReactElement => {
           </Button>
         )}
       </div>
-      {lastStep && formContent.formSubmitted && submitNotificationOpen && (
+      {lastStep && formContent.formSubmitted && showSubmitNotification && (
         <Notification
           className="submit-notification"
           label={t(`${formContent.selectedForm}:notifications:success:label`)}
           type={'success'}
           dismissible
           closeButtonLabelText="Close notification"
-          onClose={() => setSubmitNotificationOpen(false)}>
+          onClose={() => setShowSubmitNotification(false)}>
           {t(`${formContent.selectedForm}:notifications:success:text`, {
             newDueDate: formatDate(dueDateFormValues.newDueDate)
           })}
         </Notification>
       )}
       {lastStep && formContent.formSubmitted && (
-        <a href="/">
-          <Button className="wide-button" role="link" variant="primary">
-            {t('common:to-mainpage')}
-          </Button>
-        </a>
+        <div ref={mainPageButtonRef}>
+          <a href="/">
+            <Button className="wide-button" role="link" variant="primary">
+              {t('common:to-mainpage')}
+            </Button>
+          </a>
+        </div>
       )}
     </div>
   );

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   IconArrowLeft,
   IconArrowRight,
+  IconThumbsUp,
   Notification,
   Stepper
 } from 'hds-react';
@@ -17,7 +18,10 @@ import {
   setActive,
   setSteps
 } from './formStepperSlice';
-import { FormId, selectFormContent } from '../formContent/formContentSlice';
+import {
+  selectFormContent,
+  setFormSubmitted
+} from '../formContent/formContentSlice';
 import { selectDueDateFormValues } from '../extendDueDate/extendDueDateFormSlice';
 import './FormStepper.css';
 
@@ -35,10 +39,10 @@ const FormStepper = (props: Props): React.ReactElement => {
   const lastStep = activeStepIndex === steps.length - 1;
   const [submitNotificationOpen, setSubmitNotificationOpen] = useState(true);
 
-  const handleSubmit = () => {
+  function handleSubmit() {
     setSubmitNotificationOpen(true);
-    props.onSubmit();
-  };
+    dispatch(setFormSubmitted(true));
+  }
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));
@@ -70,13 +74,20 @@ const FormStepper = (props: Props): React.ReactElement => {
             variant="primary">
             {t('common:next')}
           </Button>
+        ) : formContent.formSubmitted ? (
+          <Button
+            iconLeft={<IconThumbsUp />}
+            onClick={handleSubmit}
+            variant="success">
+            {t(`${formContent.selectedForm}:submit-success`)}
+          </Button>
         ) : (
           <Button
             className="submit-button"
             onClick={handleSubmit}
             variant="primary"
             disabled={formContent.submitDisabled}>
-            {formContent.selectedForm === 'dueDate'
+            {formContent.selectedForm === 'due-date'
               ? t('due-date:submit')
               : t('common:send')}
           </Button>
@@ -85,19 +96,22 @@ const FormStepper = (props: Props): React.ReactElement => {
       {lastStep && formContent.formSubmitted && submitNotificationOpen && (
         <Notification
           className="submit-notification"
-          label={
-            formContent.selectedForm == FormId.DUEDATE &&
-            t('due-date:notifications:success:label')
-          }
+          label={t(`${formContent.selectedForm}:notifications:success:label`)}
           type={'success'}
           dismissible
           closeButtonLabelText="Close notification"
           onClose={() => setSubmitNotificationOpen(false)}>
-          {formContent.selectedForm == FormId.DUEDATE &&
-            t('due-date:notifications:success:text', {
-              newDueDate: formatDate(dueDateFormValues.newDueDate)
-            })}
+          {t(`${formContent.selectedForm}:notifications:success:text`, {
+            newDueDate: formatDate(dueDateFormValues.newDueDate)
+          })}
         </Notification>
+      )}
+      {lastStep && formContent.formSubmitted && (
+        <a href="/">
+          <Button className="wide-button" role="link" variant="primary">
+            {t('common:to-mainpage')}
+          </Button>
+        </a>
       )}
     </div>
   );

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -40,10 +40,10 @@ const FormStepper = (props: Props): React.ReactElement => {
   const [showSubmitNotification, setShowSubmitNotification] = useState(false);
   const mainPageButtonRef = useRef<null | HTMLDivElement>(null);
 
-  function handleSubmit() {
+  const handleSubmit = () => {
     dispatch(setFormSubmitted(true));
     setShowSubmitNotification(true);
-  }
+  };
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -93,9 +93,7 @@ const FormStepper = (props: Props): React.ReactElement => {
             onClick={handleSubmit}
             variant="primary"
             disabled={formContent.submitDisabled}>
-            {formContent.selectedForm === 'due-date'
-              ? t('due-date:submit')
-              : t('common:send')}
+            {t(`${formContent.selectedForm}:submit`)}
           </Button>
         )}
       </div>

--- a/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
+++ b/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
@@ -29,9 +29,9 @@ const ParkingFineAppeal = (): React.ReactElement => {
     }
   ];
 
-  function handleSubmit() {
+  const handleSubmit = () => {
     //console.log('submit parking fine appeal form');
-  }
+  };
 
   useEffect(() => {
     dispatch(setSelectedForm(FormId.PARKINGFINE));

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -1,6 +1,8 @@
 import { Button, Card, IconCopy, TextArea, TextInput } from 'hds-react';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { setSubmitDisabled } from '../formContent/formContentSlice';
 import './ParkingFineSummary.css';
 
 /**
@@ -12,6 +14,11 @@ import './ParkingFineSummary.css';
 
 const ParkingFineSummary = (): React.ReactElement => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setSubmitDisabled(false));
+  }, [dispatch]);
 
   return (
     <>
@@ -127,8 +134,8 @@ const ParkingFineSummary = (): React.ReactElement => {
         <TextInput
           className="info-field"
           id="dueDate"
-          label={t('common:fine-info:due-date:label')}
-          value={t('common:fine-info:due-date:placeholder')}
+          label={t('common:fine-info:dueDate:label')}
+          value={t('common:fine-info:dueDate:placeholder')}
           readOnly
         />
       </div>

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -134,8 +134,8 @@ const ParkingFineSummary = (): React.ReactElement => {
         <TextInput
           className="info-field"
           id="dueDate"
-          label={t('common:fine-info:dueDate:label')}
-          value={t('common:fine-info:dueDate:placeholder')}
+          label={t('common:fine-info:due-date:label')}
+          value={t('common:fine-info:due-date:placeholder')}
           readOnly
         />
       </div>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -2,7 +2,6 @@
   "common": {
     "previous": "Edellinen",
     "next": "Seuraava",
-    "send": "Lähetä",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "copy-barcode": "Kopioi virtuaaliviivakoodi",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
@@ -96,7 +95,8 @@
         "label": "Olemme vastaanottaneet oikaisuvaatimuksesi",
         "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
       }
-    }
+    },
+    "submit": "Lähetä"
   },
   "due-date": {
     "title": "Pysäköintivirhemaksun eräpäivän siirto 30 päivällä",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -7,6 +7,7 @@
     "copy-barcode": "Kopioi virtuaaliviivakoodi",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",
+    "to-mainpage": "Siirry pysäköinnin asiointiin",
     "aria": {
       "open-external": "Avaa toisen verkkosivun.",
       "open-new-tab": "Avautuu uudessa välilehdessä."
@@ -71,6 +72,7 @@
     "make-rectification": "Tehdä oikaisuvaatimuksen",
     "pay-fine": "Maksaa pysäköintivirhemaksun",
     "to-payment": "Maksamaan",
+    "submit-success": "Lähetys onnistui",
     "vehicle-info": {
       "type": {
         "label": "Ajoneuvolaji",
@@ -88,6 +90,12 @@
         "label": "Väri",
         "placeholder": "Punainen"
       }
+    },
+    "notifications": {
+      "success": {
+        "label": "Olemme vastaanottaneet oikaisuvaatimuksesi",
+        "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
+      }
     }
   },
   "due-date": {
@@ -97,6 +105,7 @@
       "step2": "Eräpäivän siirto"
     },
     "new-due-date": "Uusi eräpäivä",
+    "submit-success": "Siirto onnistui",
     "notifications": {
       "allowed": {
         "label": "Voit siirtää eräpäivää",


### PR DESCRIPTION
This PR:
- Changes submit button styling when form is submitted
- Adds button that takes user to the main page
- Ensures that submit notification and main page button are visible by scrolling down if needed
- Improves dynamic translations
- Adds "form submitted" notification to parking fine appeal form

Missing:
- Loading spinner from submit button, maybe easier to add when the form submitting logic is there
- "Form submitted" notification on parking fine appeal form should have different text when user has chosen to get the decision via mail

![Screenshot 2022-11-21 at 17 35 46](https://user-images.githubusercontent.com/36920208/203099205-748035ba-9dd4-4131-869d-abfef721129b.png)
