### PR TITLE
Bump hds-react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "graphql.macro": "^1.4.2",
     "hds-core": "1.5.1",
     "hds-design-tokens": "1.5.1",
-    "hds-react": "^2.4.0",
+    "hds-react": "^2.7.0",
     "http-status-typed": "^1.0.0",
     "i18next": "^22.0.2",
     "jest-fetch-mock": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6299,20 +6299,20 @@ hds-core@1.5.1:
   resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.5.1.tgz#ed802a7b5a39c242b8aa92cea6bb9f5844ed2eaa"
   integrity sha512-PJy4+RqpxoyQNQOM5dOeeTBiJo4EDukSjvMrJMMMZ9T36Q9n3uxIbtMObPkjhYFvcVwiXD03ZvZ1LDk1VPmMlQ==
 
-hds-core@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.4.0.tgz#598c8ed1919a95e40cdd9f754371fb87834590af"
-  integrity sha512-23MhU/KJsVKo1dEm2xOf4feSAd0uHYB0yjOQEOYDPRVRrd+W9IRFGjbcVKsQDr1aWWjtVJK5rEgEVsSA3bAf0A==
+hds-core@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.7.0.tgz#2a348a790c3ef12b62990473add629e856fd2d6c"
+  integrity sha512-JH4SIIEIVXA/u2gluWswQI4ut6uZXUXIDviiBTAwgd6iGuacpfoorxFmFjJ1LBmHeViOvpc32f3YhqAk0nkiqQ==
 
 hds-design-tokens@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.5.1.tgz#90eb4ce89a311eb85c01d630d305ec1bc7c0d1a2"
   integrity sha512-yvDsLz3lK/PavNijrex+de1137RinfkbAjuggL+wQbLVa5Q1qb1kh59kCZ/0qiVxU/IIS5hkAG6JOzzd0z8Oyg==
 
-hds-react@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.4.0.tgz#77bc1cf9c51f08198a2d8e64e2466853f240795e"
-  integrity sha512-mPb9WUbh3TUFyfIrFNQzAPw6EKRJDtYdSJXgJfxg2WMYPwnlmZS4IeUqT6kpGOHCIY18q/F0WQEVsixDAMSZ+g==
+hds-react@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.7.0.tgz#bef3bc7dd745c462a6a170968ec51de6f8527e54"
+  integrity sha512-/eAA9axQh//F/+GcBlTemoMA+6Myhpzg0Sbi+tmTqKIJ/5QnLUuY+S7oWCTTsUcwfZpNmlgMYkkSf+SG2Hm2/Q==
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/styled-base" "^11.0.0"
@@ -6324,7 +6324,7 @@ hds-react@^2.4.0:
     crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "2.4.0"
+    hds-core "2.7.0"
     kashe "1.0.4"
     lodash.get "^4.4.2"
     lodash.isequal "4.5.0"
@@ -6342,7 +6342,6 @@ hds-react@^2.4.0:
     react-spring "9.3.0"
     react-use-measure "2.0.1"
     react-virtual "2.2.7"
-    typescript "4.5.5"
 
 he@^1.2.0:
   version "1.2.0"
@@ -10880,11 +10879,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 typescript@^4.7.0:
   version "4.7.4"


### PR DESCRIPTION
This PR:
- Updates hds-react package to version 2.7.0