### PR TITLE
Update notification styles

### DIFF
--- a/src/components/extendDueDate/ExtendDueDateForm.css
+++ b/src/components/extendDueDate/ExtendDueDateForm.css
@@ -1,3 +1,7 @@
+.form-body {
+  margin: 50px 0 12px;
+}
+
 .info-container {
   display: grid;
   grid-template-columns: auto auto auto;
@@ -6,5 +10,5 @@
 }
 
 .email-notification {
-  margin: 24px 0 12px;
+  margin-top: 24px;
 }

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -32,7 +32,6 @@ const ExtendDueDateForm = (): React.ReactElement => {
     dispatch(
       setEmailConfirmationChecked(!dueDateFormValues.emailConfirmationChecked)
     );
-    setEmailNotificationOpen(true);
   };
 
   // Allow extension only if due date has not passed
@@ -44,8 +43,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
   }, [dispatch, extensionAllowed]);
 
   return (
-    <div data-testid="extendDueDateForm">
-      <p>{t('common:required-fields')}</p>
+    <div data-testid="extendDueDateForm" className="form-body">
       {infoNotificationOpen && (
         <Notification
           label={
@@ -105,7 +103,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
         onChange={handleCheckedChange}
         disabled={!extensionAllowed || formContent.formSubmitted}
       />
-      {dueDateFormValues.emailConfirmationChecked && emailNotificationOpen && (
+      {emailNotificationOpen && (
         <Notification
           className="email-notification"
           size="small"

--- a/src/components/extendDueDate/extendDueDate.test.tsx
+++ b/src/components/extendDueDate/extendDueDate.test.tsx
@@ -52,6 +52,7 @@ describe('extend due date form', () => {
         </Provider>
       );
 
+      // Parking fine info is visible
       const refNumberEl = screen.getByRole('textbox', {
         name: t('common:fine-info:ref-number:label')
       });
@@ -79,6 +80,13 @@ describe('extend due date form', () => {
       expect(newDueDateEl).toBeInTheDocument();
       expect(newDueDateEl).toHaveValue('11.01.2023');
 
+      // Due date notification is visible
+      const infoNotification = screen.getByRole('heading', {
+        name: t('due-date:notifications:allowed:label')
+      });
+      expect(infoNotification).toBeInTheDocument();
+
+      // Checkbox is visible and clickable
       const checkbox = screen.getByRole('checkbox', {
         name: t('common:email-confirmation')
       });
@@ -89,6 +97,12 @@ describe('extend due date form', () => {
         checkbox.click();
       });
       expect(checkbox).toBeChecked();
+
+      // Email confirmation notification is visible
+      const emailInfoNotification = screen.getByRole('heading', {
+        name: t('due-date:notifications:email-confirmation:label')
+      });
+      expect(emailInfoNotification).toBeInTheDocument();
     });
   });
 });

--- a/src/components/formStepper/FormStepper.css
+++ b/src/components/formStepper/FormStepper.css
@@ -22,6 +22,7 @@
 
 .submit-notification {
   margin-bottom: 24px;
+  z-index: 100;
 }
 
 .wide-button {

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -101,7 +101,9 @@ const FormStepper = (props: Props): React.ReactElement => {
         <Notification
           className="submit-notification"
           label={t(`${formContent.selectedForm}:notifications:success:label`)}
+          position="bottom-right"
           type={'success'}
+          autoClose
           dismissible
           closeButtonLabelText="Close notification"
           onClose={() => setShowSubmitNotification(false)}>

--- a/src/components/parkingFineSummary/ParkingFineSummary.css
+++ b/src/components/parkingFineSummary/ParkingFineSummary.css
@@ -3,6 +3,7 @@
   grid-template-columns: 510px auto auto;
   grid-template-rows: repeat(6, 130px);
   grid-gap: 12px 12px;
+  margin-top: 50px;
 }
 
 .info-field {


### PR DESCRIPTION
Because HDS advices not to use dynamic inline notifications, this PR changes
* email confirmation notification to be static
* submit notification to be a toast that closes automatically

![Screenshot 2022-11-24 at 10 06 23](https://user-images.githubusercontent.com/36920208/203727207-0d7242a1-cde8-41c8-9db2-633e53222ef1.png)
