### PR TITLE
Update rectification view of moved car form

### DIFF
--- a/src/components/rectification/RectificationForm.css
+++ b/src/components/rectification/RectificationForm.css
@@ -51,6 +51,10 @@
   grid-row: 9;
 }
 
+.rectification-draft-button {
+  margin: 36px 0 12px;
+}
+
 @media only screen and (max-width: 768px) {
   .rectification-form-user-details {
     grid-template-columns: 1fr 1fr;

--- a/src/components/rectification/RectificationForm.css
+++ b/src/components/rectification/RectificationForm.css
@@ -5,6 +5,18 @@
   grid-gap: 24px;
 }
 
+.rectification-info-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin: 24px 0 24px;
+}
+
+.rectification-user-section {
+  flex: 1;
+  min-width: 500px;
+}
+
 .rectification-textarea {
   grid-column: 2;
   grid-row: 1 / 7;
@@ -24,7 +36,6 @@
 .rectification-form-user-details {
   margin-top: 24px;
   display: grid;
-  grid-template-columns: 1fr 3fr;
   grid-template-rows: repeat(3, auto);
 }
 
@@ -38,4 +49,31 @@
 
 .rectification-decision-choice {
   grid-row: 9;
+}
+
+@media only screen and (max-width: 768px) {
+  .rectification-form-user-details {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .rectification-poa-fileinput {
+    flex: 1;
+    min-width: 300px;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .rectification-form-user-details {
+    grid-template-columns: 1fr 3fr;
+  }
+
+  .rectification-form-user-details.small {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .rectification-poa-fileinput {
+    flex: 1;
+    margin-top: 5px;
+    min-width: 450px;
+  }
 }

--- a/src/components/rectification/RectificationForm.test.tsx
+++ b/src/components/rectification/RectificationForm.test.tsx
@@ -1,20 +1,46 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import RectificationForm from './RectificationForm';
+import { Provider } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { axe } from 'jest-axe';
 
 // eslint-disable-next-line no-magic-numbers
 jest.setTimeout(10000);
 
 describe('Component', () => {
+  const formContentSliceMock = createSlice({
+    name: 'formContent',
+    initialState: {
+      formSubmitted: false,
+      selectedForm: 'parking-fine',
+      submitDisabled: true
+    },
+    reducers: {}
+  });
+
+  const store = configureStore({
+    reducer: {
+      formContent: formContentSliceMock.reducer
+    }
+  });
+
   it('matches snapshot', async () => {
-    const { container } = render(<RectificationForm />);
+    const { container } = render(
+      <Provider store={store}>
+        <RectificationForm />
+      </Provider>
+    );
 
     await waitFor(() => expect(container).toMatchSnapshot());
   });
 
   it('passes A11y checks', async () => {
-    const { container } = render(<RectificationForm />);
+    const { container } = render(
+      <Provider store={store}>
+        <RectificationForm />
+      </Provider>
+    );
 
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/components/rectification/RectificationForm.test.tsx
+++ b/src/components/rectification/RectificationForm.test.tsx
@@ -8,12 +8,50 @@ import { axe } from 'jest-axe';
 // eslint-disable-next-line no-magic-numbers
 jest.setTimeout(10000);
 
-describe('Component', () => {
+describe('Component in parking fine appeal form', () => {
   const formContentSliceMock = createSlice({
     name: 'formContent',
     initialState: {
       formSubmitted: false,
       selectedForm: 'parking-fine',
+      submitDisabled: true
+    },
+    reducers: {}
+  });
+
+  const store = configureStore({
+    reducer: {
+      formContent: formContentSliceMock.reducer
+    }
+  });
+
+  it('matches snapshot', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <RectificationForm />
+      </Provider>
+    );
+
+    await waitFor(() => expect(container).toMatchSnapshot());
+  });
+
+  it('passes A11y checks', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <RectificationForm />
+      </Provider>
+    );
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('Component in moved car form', () => {
+  const formContentSliceMock = createSlice({
+    name: 'formContent',
+    initialState: {
+      formSubmitted: false,
+      selectedForm: 'moved-car',
       submitDisabled: true
     },
     reducers: {}

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
   Checkbox,
@@ -13,6 +14,7 @@ import {
   TextInput
 } from 'hds-react';
 import { useClient } from '../../client/hooks';
+import { FormId, selectFormContent } from '../formContent/formContentSlice';
 
 import './RectificationForm.css';
 
@@ -23,6 +25,7 @@ const RectificationForm = () => {
 
   const { getUser } = useClient();
   const user = getUser();
+  const selectedForm = useSelector(selectFormContent).selectedForm;
 
   const [checked, setChecked] = useState(false);
   const [newEmailSelected, setNewEmailSelected] = useState(false);
@@ -44,17 +47,23 @@ const RectificationForm = () => {
     setDecision(e.target.value);
   };
 
-  const relations = ['driver', 'owner', 'holder'];
+  const relations =
+    selectedForm == FormId.MOVEDCAR
+      ? ['driver', 'owner', 'poa-holder']
+      : ['driver', 'owner', 'holder'];
 
   return (
     <>
       <p>{t('common:required-fields')}</p>
       <div className="userDetails">
-        <SelectionGroup label={t('rectification:relation')}>
+        <SelectionGroup
+          label={t(`rectification:relation-info:${selectedForm}:relation`)}>
           {relations.map(relation => (
             <RadioButton
               key={relation}
-              label={t(`rectification:${relation}`)}
+              label={t(
+                `rectification:relation-info:${selectedForm}:${relation}`
+              )}
               id={relation}
               value={relation}
               checked={vehicleRelation === relation}

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -29,7 +29,7 @@ const RectificationForm = () => {
   const { getUser } = useClient();
   const user = getUser();
   const selectedForm = useSelector(selectFormContent).selectedForm;
-  const movedCarFormSelected = selectedForm == FormId.MOVEDCAR;
+  const movedCarFormSelected = selectedForm === FormId.MOVEDCAR;
 
   const [checked, setChecked] = useState(false);
   const [newEmailSelected, setNewEmailSelected] = useState(false);

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -121,7 +121,6 @@ const RectificationForm = () => {
             <div className="rectification-poa-fileinput">
               <FileInput
                 language={i18n.language as Language}
-                multiple
                 label={t('rectification:attach-poa')}
                 id="rectificationPOAFile"
                 onChange={() => null}

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -26,6 +26,7 @@ const RectificationForm = () => {
   const { getUser } = useClient();
   const user = getUser();
   const selectedForm = useSelector(selectFormContent).selectedForm;
+  const movedCarFormSelected = selectedForm == FormId.MOVEDCAR;
 
   const [checked, setChecked] = useState(false);
   const [newEmailSelected, setNewEmailSelected] = useState(false);
@@ -47,55 +48,79 @@ const RectificationForm = () => {
     setDecision(e.target.value);
   };
 
-  const relations =
-    selectedForm == FormId.MOVEDCAR
-      ? ['driver', 'owner', 'poa-holder']
-      : ['driver', 'owner', 'holder'];
+  const relations = movedCarFormSelected
+    ? ['driver', 'owner', 'poa-holder']
+    : ['driver', 'owner', 'holder'];
 
   return (
     <>
       <p>{t('common:required-fields')}</p>
-      <div className="userDetails">
-        <SelectionGroup
-          label={t(`rectification:relation-info:${selectedForm}:relation`)}>
-          {relations.map(relation => (
-            <RadioButton
-              key={relation}
-              label={t(
-                `rectification:relation-info:${selectedForm}:${relation}`
-              )}
-              id={relation}
-              value={relation}
-              checked={vehicleRelation === relation}
-              onChange={handleVehicleRelation}
-            />
-          ))}
-        </SelectionGroup>
+      <div>
+        <div className="rectification-info-container">
+          <div className="rectification-user-section">
+            <SelectionGroup
+              label={t(`rectification:relation-info:${selectedForm}:relation`)}>
+              {relations.map(relation => (
+                <RadioButton
+                  key={relation}
+                  label={t(
+                    `rectification:relation-info:${selectedForm}:${relation}`
+                  )}
+                  id={relation}
+                  value={relation}
+                  checked={vehicleRelation === relation}
+                  onChange={handleVehicleRelation}
+                />
+              ))}
+            </SelectionGroup>
 
-        <div className="rectification-form-user-details">
-          <TextInput
-            id="fullName"
-            readOnly
-            label={t('common:name')}
-            defaultValue={user?.name as string}
-          />
-          <IconCheckCircle aria-label={t('common:fetched-from-profile-aria')} />
-          <TextInput
-            id="ssn"
-            readOnly
-            label={t('common:ssn')}
-            defaultValue="123456-789A"
-          />
-          <IconCheckCircle aria-label={t('common:fetched-from-profile-aria')} />
-          <TextInput
-            id="email"
-            readOnly
-            label={t('common:email')}
-            defaultValue={user?.email as string}
-          />
-          <IconCheckCircle aria-label={t('common:fetched-from-profile-aria')} />
+            <div
+              className={`rectification-form-user-details ${
+                movedCarFormSelected ? 'small' : ''
+              }`}>
+              <TextInput
+                id="fullName"
+                readOnly
+                label={t('common:name')}
+                defaultValue={user?.name as string}
+              />
+              <IconCheckCircle
+                aria-label={t('common:fetched-from-profile-aria')}
+              />
+              <TextInput
+                id="ssn"
+                readOnly
+                label={t('common:ssn')}
+                defaultValue="123456-789A"
+              />
+              <IconCheckCircle
+                aria-label={t('common:fetched-from-profile-aria')}
+              />
+              <TextInput
+                id="email"
+                readOnly
+                label={t('common:email')}
+                defaultValue={user?.email as string}
+              />
+              <IconCheckCircle
+                aria-label={t('common:fetched-from-profile-aria')}
+              />
+            </div>
+          </div>
+          {movedCarFormSelected && (
+            <div className="rectification-poa-fileinput">
+              <FileInput
+                language={i18n.language as Language}
+                multiple
+                label={t('rectification:attach-poa')}
+                id="rectificationPOAFile"
+                onChange={() => null}
+                dragAndDrop
+                accept={'.png, .jpg, .pdf'}
+              />
+            </div>
+          )}
         </div>
-
         <hr />
         <p>
           <IconCheckCircle aria-hidden="true" />

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -3,10 +3,13 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
+  Button,
   Checkbox,
   FileInput,
   IconCheckCircle,
+  IconUploadCloud,
   Link,
+  Notification,
   RadioButton,
   Select,
   SelectionGroup,
@@ -32,6 +35,9 @@ const RectificationForm = () => {
   const [newEmailSelected, setNewEmailSelected] = useState(false);
   const [vehicleRelation, setVehicleRelation] = useState('driver');
   const [currentCharacters, setCurrentCharacters] = useState(0);
+  const [showDraftSavedNotification, setShowDraftSavedNotification] = useState(
+    false
+  );
 
   const [decision, setDecision] = useState('toParkingService');
 
@@ -46,6 +52,10 @@ const RectificationForm = () => {
 
   const handleDecision = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDecision(e.target.value);
+  };
+
+  const handleDraftSave = () => {
+    setShowDraftSavedNotification(true);
   };
 
   const relations = movedCarFormSelected
@@ -245,6 +255,27 @@ const RectificationForm = () => {
               checked={decision === 'byMail'}
             />
           </SelectionGroup>
+        </div>
+        <div>
+          <Button
+            className="rectification-draft-button"
+            iconLeft={<IconUploadCloud />}
+            onClick={handleDraftSave}
+            variant="secondary">
+            {t('common:save-draft')}
+          </Button>
+          {showDraftSavedNotification && (
+            <Notification
+              label={t('common:notifications:draft-saved:label')}
+              position="bottom-right"
+              type={'success'}
+              autoClose
+              dismissible
+              closeButtonLabelText="Close notification"
+              onClose={() => setShowDraftSavedNotification(false)}>
+              {t('common:notifications:draft-saved:text')}
+            </Notification>
+          )}
         </div>
       </div>
     </>

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component matches snapshot 1`] = `
+exports[`Component in parking fine appeal form matches snapshot 1`] = `
 <div>
   <p>
     Pakolliset kentät on merkitty tähdellä *
@@ -521,6 +521,904 @@ exports[`Component matches snapshot 1`] = `
               aria-required="true"
               class="Select-module_menu__1H2aU"
               id="hds-select-1-menu"
+              role="listbox"
+              style="max-height: 260px;"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="phone"
+          >
+            Puhelinnumero
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="phone"
+              placeholder="Esim. 401234567"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="IBAN"
+        >
+          Pankkitilinumero (IBAN)
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="IBAN"
+            placeholder="Esim. FI9780001700903330"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-fileinput"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="rectificationAttachments"
+        >
+          Liitetiedostot
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <div
+            class="FileInput-module_fileInputContainer__9N5TG"
+          >
+            <div
+              aria-hidden="true"
+              class="FileInput-module_dragAndDrop__3d3xe"
+            >
+              <div
+                class="FileInput-module_dragAndDropLabel__1pDQN"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                    />
+                    <path
+                      d="M12 1.636l5.657 5.657-1.414 1.414L13 5.465V18h-2V5.465L7.757 8.707 6.343 7.293 12 1.636zM5 15v5h14v-5h2v7H3v-7h2z"
+                      fill="currentColor"
+                    />
+                  </g>
+                </svg>
+                <span
+                  class="FileInput-module_dragAndDropLabelText__3AJ4P"
+                >
+                  Raahaa tiedostot tähän
+                </span>
+              </div>
+            </div>
+            <div
+              class="FileInput-module_dragAndDropHelperText__31Ljw"
+            >
+              tai valitse tiedostot laitteeltasi
+            </div>
+            <div
+              class="FileInput-module_fileInputWrapper__1E8Jf"
+            >
+              <button
+                aria-hidden="true"
+                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  aria-hidden="true"
+                  class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M13 6v5h5v2h-5v5h-2v-5H6v-2h5V6z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </div>
+                <span
+                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                >
+                  Lisää tiedostoja
+                </span>
+              </button>
+              <input
+                accept=".png, .jpg, .pdf"
+                aria-describedby="rectificationAttachments-helper rectificationAttachments-info"
+                class="FileInput-module_fileInput__hClRc"
+                id="rectificationAttachments"
+                multiple=""
+                type="file"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="TextInput-module_infoText__zHOGs text-input_hds-text-input__info-text__3bqzy"
+          id="rectificationAttachments-info"
+        >
+          Yhtään tiedostoa ei ole valittu.
+        </div>
+        <div
+          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
+          id="rectificationAttachments-helper"
+        >
+          Vain .png,  .jpg ja  .pdf tiedostoja.
+        </div>
+      </div>
+      <ul
+        aria-label="Yhtään tiedostoa ei ole valittu."
+        class="FileInput-module_fileList__drFD1"
+        id="rectificationAttachments-list"
+        tabindex="-1"
+      />
+      <fieldset
+        class="SelectionGroup-module_selectionGroup__6Jxu8 rectification-decision-choice"
+      >
+        <legend
+          class="SelectionGroup-module_label__qlluz"
+        >
+          Haluan päätöksen
+           
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </legend>
+        <div
+          class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
+        >
+          <div>
+            <div
+              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            >
+              <input
+                checked=""
+                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                id="toParkingService"
+                type="radio"
+                value="toParkingService"
+              />
+              <label
+                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                for="toParkingService"
+              >
+                Pysäköinnin asiointikansiooni
+              </label>
+            </div>
+          </div>
+          <div>
+            <div
+              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            >
+              <input
+                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                id="byMail"
+                type="radio"
+                value="byMail"
+              />
+              <label
+                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                for="byMail"
+              >
+                Kirjeitse antamaani osoitteeseen
+              </label>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component in moved car form matches snapshot 1`] = `
+<div>
+  <p>
+    Pakolliset kentät on merkitty tähdellä *
+  </p>
+  <div>
+    <div
+      class="rectification-info-container"
+    >
+      <div
+        class="rectification-user-section"
+      >
+        <fieldset
+          class="SelectionGroup-module_selectionGroup__6Jxu8"
+        >
+          <legend
+            class="SelectionGroup-module_label__qlluz"
+          >
+            Teen oikaisuvaatimuksen *
+             
+          </legend>
+          <div
+            class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
+          >
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  checked=""
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="driver"
+                  type="radio"
+                  value="driver"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="driver"
+                >
+                  Ajoneuvon kuljettajana
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="owner"
+                  type="radio"
+                  value="owner"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="owner"
+                >
+                  Ajoneuvon omistajana
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="poa-holder"
+                  type="radio"
+                  value="poa-holder"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="poa-holder"
+                >
+                  Valtakirjalla
+                </label>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+        <div
+          class="rectification-form-user-details small"
+        >
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="fullName"
+            >
+              Nimi *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="fullName"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="ssn"
+            >
+              Henkilötunnus *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="ssn"
+                readonly=""
+                type="text"
+                value="123456-789A"
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="email"
+            >
+              Sähköpostiosoite *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="email"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        class="rectification-poa-fileinput"
+      >
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="rectificationPOAFile"
+          >
+            Liitä valtakirja
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <div
+              class="FileInput-module_fileInputContainer__9N5TG"
+            >
+              <div
+                aria-hidden="true"
+                class="FileInput-module_dragAndDrop__3d3xe"
+              >
+                <div
+                  class="FileInput-module_dragAndDropLabel__1pDQN"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M12 1.636l5.657 5.657-1.414 1.414L13 5.465V18h-2V5.465L7.757 8.707 6.343 7.293 12 1.636zM5 15v5h14v-5h2v7H3v-7h2z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    class="FileInput-module_dragAndDropLabelText__3AJ4P"
+                  >
+                    Raahaa tiedostot tähän
+                  </span>
+                </div>
+              </div>
+              <div
+                class="FileInput-module_dragAndDropHelperText__31Ljw"
+              >
+                tai valitse tiedostot laitteeltasi
+              </div>
+              <div
+                class="FileInput-module_fileInputWrapper__1E8Jf"
+              >
+                <button
+                  aria-hidden="true"
+                  class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M13 6v5h5v2h-5v5h-2v-5H6v-2h5V6z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                  <span
+                    class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                  >
+                    Lisää tiedostoja
+                  </span>
+                </button>
+                <input
+                  accept=".png, .jpg, .pdf"
+                  aria-describedby="rectificationPOAFile-helper rectificationPOAFile-info"
+                  class="FileInput-module_fileInput__hClRc"
+                  id="rectificationPOAFile"
+                  multiple=""
+                  type="file"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="TextInput-module_infoText__zHOGs text-input_hds-text-input__info-text__3bqzy"
+            id="rectificationPOAFile-info"
+          >
+            Yhtään tiedostoa ei ole valittu.
+          </div>
+          <div
+            class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
+            id="rectificationPOAFile-helper"
+          >
+            Vain .png,  .jpg ja  .pdf tiedostoja.
+          </div>
+        </div>
+        <ul
+          aria-label="Yhtään tiedostoa ei ole valittu."
+          class="FileInput-module_fileList__drFD1"
+          id="rectificationPOAFile-list"
+          tabindex="-1"
+        />
+      </div>
+    </div>
+    <hr />
+    <p>
+      <svg
+        aria-hidden="true"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <rect
+            height="24"
+            width="24"
+          />
+          <path
+            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+            fill="currentColor"
+          />
+        </g>
+      </svg>
+      Merkityt tiedot on haettu Helsinki-profiilistasi.
+      <a
+        aria-label="Siirry Helsinki-profiiliin muokataksesi tietoja. Avautuu uudessa välilehdessä. Avaa toisen verkkosivun."
+        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F"
+        href="https://profiili.test.kuva.hel.ninja"
+        rel="noopener"
+        target="_blank"
+      >
+        Siirry Helsinki-profiiliin muokataksesi tietoja.
+        <svg
+          aria-hidden="true"
+          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Link-module_icon__3ReCc link_icon__i_HqN Link-module_verticalAlignSmallOrMediumIcon__3FOVU link_vertical-align-small-or-medium-icon__25J0G"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M0 0h24v24H0z"
+            />
+            <path
+              d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+      </a>
+    </p>
+    <div
+      class="rectification-form-container"
+    >
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-textarea"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="rectification-content"
+        >
+          Oikaisuvaatimuksen sisältö
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <textarea
+            aria-describedby="rectification-content-helper"
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="rectification-content"
+            required=""
+          />
+        </div>
+        
+        <div
+          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
+          id="rectification-content-helper"
+        >
+          0/2500
+        </div>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="newEmail"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="newEmail"
+        >
+          Haluan ilmoitukset asian käsittelystä eri sähköpostiosoitteeseen
+        </label>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="newEmailAddress"
+        >
+          Sähköpostiosoite *
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            disabled=""
+            id="newEmailAddress"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="newEmailConfirm"
+        >
+          Kirjoita sähköpostiosoite uudelleen
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            disabled=""
+            id="newEmailConfirm"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="address"
+        >
+          Osoite
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="address"
+            placeholder="Esim. Elimäenkatu 5"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="rectification-subgrid"
+      >
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="zipCode"
+          >
+            Postinumero
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="zipCode"
+              placeholder="Esim. 00100"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="city"
+          >
+            Postitoimipaikka
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="city"
+              placeholder="Esim. Helsinki"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="Select-module_root__Ka5uO"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="hds-select-8-toggle-button"
+            id="hds-select-8-label"
+          >
+            Maakoodi
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="Select-module_wrapper__1WQXs"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
+              aria-owns="hds-select-8-menu"
+              class="Select-module_button__1aIsm"
+              id="hds-select-8-toggle-button"
+              type="button"
+            >
+              <span
+                class="Select-module_buttonLabel__1fqu5"
+              >
+                Suomi (+358)
+              </span>
+              <svg
+                aria-hidden="true"
+                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                  />
+                  <path
+                    d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                    fill="currentColor"
+                  />
+                </g>
+              </svg>
+            </button>
+            <ul
+              aria-labelledby="hds-select-8-label"
+              aria-required="true"
+              class="Select-module_menu__1H2aU"
+              id="hds-select-8-menu"
               role="listbox"
               style="max-height: 260px;"
               tabindex="-1"

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -5,207 +5,213 @@ exports[`Component matches snapshot 1`] = `
   <p>
     Pakolliset kentät on merkitty tähdellä *
   </p>
-  <div
-    class="userDetails"
-  >
-    <fieldset
-      class="SelectionGroup-module_selectionGroup__6Jxu8"
-    >
-      <legend
-        class="SelectionGroup-module_label__qlluz"
-      >
-        Olen ajoneuvon *
-         
-      </legend>
-      <div
-        class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
-      >
-        <div>
-          <div
-            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-          >
-            <input
-              checked=""
-              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-              id="driver"
-              type="radio"
-              value="driver"
-            />
-            <label
-              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-              for="driver"
-            >
-              Kuljettaja
-            </label>
-          </div>
-        </div>
-        <div>
-          <div
-            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-          >
-            <input
-              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-              id="owner"
-              type="radio"
-              value="owner"
-            />
-            <label
-              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-              for="owner"
-            >
-              Omistaja
-            </label>
-          </div>
-        </div>
-        <div>
-          <div
-            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-          >
-            <input
-              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-              id="holder"
-              type="radio"
-              value="holder"
-            />
-            <label
-              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-              for="holder"
-            >
-              Haltija
-            </label>
-          </div>
-        </div>
-      </div>
-    </fieldset>
+  <div>
     <div
-      class="rectification-form-user-details"
+      class="rectification-info-container"
     >
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="rectification-user-section"
       >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="fullName"
+        <fieldset
+          class="SelectionGroup-module_selectionGroup__6Jxu8"
         >
-          Nimi *
-        </label>
+          <legend
+            class="SelectionGroup-module_label__qlluz"
+          >
+            Olen ajoneuvon *
+             
+          </legend>
+          <div
+            class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
+          >
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  checked=""
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="driver"
+                  type="radio"
+                  value="driver"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="driver"
+                >
+                  Kuljettaja
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="owner"
+                  type="radio"
+                  value="owner"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="owner"
+                >
+                  Omistaja
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="holder"
+                  type="radio"
+                  value="holder"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="holder"
+                >
+                  Haltija
+                </label>
+              </div>
+            </div>
+          </div>
+        </fieldset>
         <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          class="rectification-form-user-details "
         >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="fullName"
-            readonly=""
-            type="text"
-            value=""
-          />
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="fullName"
+            >
+              Nimi *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="fullName"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="ssn"
+            >
+              Henkilötunnus *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="ssn"
+                readonly=""
+                type="text"
+                value="123456-789A"
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="email"
+            >
+              Sähköpostiosoite *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="email"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
         </div>
       </div>
-      <svg
-        aria-label="Tieto haettu Helsinki-profiilista"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fill-rule="evenodd"
-        >
-          <rect
-            height="24"
-            width="24"
-          />
-          <path
-            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="ssn"
-        >
-          Henkilötunnus *
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="ssn"
-            readonly=""
-            type="text"
-            value="123456-789A"
-          />
-        </div>
-      </div>
-      <svg
-        aria-label="Tieto haettu Helsinki-profiilista"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fill-rule="evenodd"
-        >
-          <rect
-            height="24"
-            width="24"
-          />
-          <path
-            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="email"
-        >
-          Sähköpostiosoite *
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="email"
-            readonly=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <svg
-        aria-label="Tieto haettu Helsinki-profiilista"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fill-rule="evenodd"
-        >
-          <rect
-            height="24"
-            width="24"
-          />
-          <path
-            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
     </div>
     <hr />
     <p>

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -306,7 +306,7 @@ exports[`Component in moved car form matches snapshot 1`] = `
                   <span
                     class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
                   >
-                    Lisää tiedostoja
+                    Lisää tiedosto
                   </span>
                 </button>
                 <input
@@ -314,7 +314,6 @@ exports[`Component in moved car form matches snapshot 1`] = `
                   aria-describedby="rectificationPOAFile-helper rectificationPOAFile-info"
                   class="FileInput-module_fileInput__hClRc"
                   id="rectificationPOAFile"
-                  multiple=""
                   type="file"
                 />
               </div>

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -1,775 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component in parking fine appeal form matches snapshot 1`] = `
-<div>
-  <p>
-    Pakolliset kentät on merkitty tähdellä *
-  </p>
-  <div>
-    <div
-      class="rectification-info-container"
-    >
-      <div
-        class="rectification-user-section"
-      >
-        <fieldset
-          class="SelectionGroup-module_selectionGroup__6Jxu8"
-        >
-          <legend
-            class="SelectionGroup-module_label__qlluz"
-          >
-            Olen ajoneuvon *
-             
-          </legend>
-          <div
-            class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
-          >
-            <div>
-              <div
-                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-              >
-                <input
-                  checked=""
-                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                  id="driver"
-                  type="radio"
-                  value="driver"
-                />
-                <label
-                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                  for="driver"
-                >
-                  Kuljettaja
-                </label>
-              </div>
-            </div>
-            <div>
-              <div
-                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-              >
-                <input
-                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                  id="owner"
-                  type="radio"
-                  value="owner"
-                />
-                <label
-                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                  for="owner"
-                >
-                  Omistaja
-                </label>
-              </div>
-            </div>
-            <div>
-              <div
-                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-              >
-                <input
-                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                  id="holder"
-                  type="radio"
-                  value="holder"
-                />
-                <label
-                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                  for="holder"
-                >
-                  Haltija
-                </label>
-              </div>
-            </div>
-          </div>
-        </fieldset>
-        <div
-          class="rectification-form-user-details "
-        >
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="fullName"
-            >
-              Nimi *
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-            >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="fullName"
-                readonly=""
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="ssn"
-            >
-              Henkilötunnus *
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-            >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="ssn"
-                readonly=""
-                type="text"
-                value="123456-789A"
-              />
-            </div>
-          </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="email"
-            >
-              Sähköpostiosoite *
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-            >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="email"
-                readonly=""
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <hr />
-    <p>
-      <svg
-        aria-hidden="true"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fill-rule="evenodd"
-        >
-          <rect
-            height="24"
-            width="24"
-          />
-          <path
-            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-      Merkityt tiedot on haettu Helsinki-profiilistasi.
-      <a
-        aria-label="Siirry Helsinki-profiiliin muokataksesi tietoja. Avautuu uudessa välilehdessä. Avaa toisen verkkosivun."
-        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F"
-        href="https://profiili.test.kuva.hel.ninja"
-        rel="noopener"
-        target="_blank"
-      >
-        Siirry Helsinki-profiiliin muokataksesi tietoja.
-        <svg
-          aria-hidden="true"
-          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Link-module_icon__3ReCc link_icon__i_HqN Link-module_verticalAlignSmallOrMediumIcon__3FOVU link_vertical-align-small-or-medium-icon__25J0G"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fill-rule="evenodd"
-          >
-            <path
-              d="M0 0h24v24H0z"
-            />
-            <path
-              d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </a>
-    </p>
-    <div
-      class="rectification-form-container"
-    >
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-textarea"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="rectification-content"
-        >
-          Oikaisuvaatimuksen sisältö
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <textarea
-            aria-describedby="rectification-content-helper"
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="rectification-content"
-            required=""
-          />
-        </div>
-        
-        <div
-          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
-          id="rectification-content-helper"
-        >
-          0/2500
-        </div>
-      </div>
-      <div
-        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
-      >
-        <input
-          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
-          id="newEmail"
-          type="checkbox"
-          value=""
-        />
-        <label
-          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
-          for="newEmail"
-        >
-          Haluan ilmoitukset asian käsittelystä eri sähköpostiosoitteeseen
-        </label>
-      </div>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="newEmailAddress"
-        >
-          Sähköpostiosoite *
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            disabled=""
-            id="newEmailAddress"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="newEmailConfirm"
-        >
-          Kirjoita sähköpostiosoite uudelleen
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            disabled=""
-            id="newEmailConfirm"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="address"
-        >
-          Osoite
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="address"
-            placeholder="Esim. Elimäenkatu 5"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        class="rectification-subgrid"
-      >
-        <div
-          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-        >
-          <label
-            class="FieldLabel-module_label__1zrXK "
-            for="zipCode"
-          >
-            Postinumero
-            <span
-              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-            >
-               
-              *
-            </span>
-          </label>
-          <div
-            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-          >
-            <input
-              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-              id="zipCode"
-              placeholder="Esim. 00100"
-              required=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-        >
-          <label
-            class="FieldLabel-module_label__1zrXK "
-            for="city"
-          >
-            Postitoimipaikka
-            <span
-              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-            >
-               
-              *
-            </span>
-          </label>
-          <div
-            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-          >
-            <input
-              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-              id="city"
-              placeholder="Esim. Helsinki"
-              required=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="Select-module_root__Ka5uO"
-        >
-          <label
-            class="FieldLabel-module_label__1zrXK "
-            for="hds-select-1-toggle-button"
-            id="hds-select-1-label"
-          >
-            Maakoodi
-            <span
-              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-            >
-               
-              *
-            </span>
-          </label>
-          <div
-            class="Select-module_wrapper__1WQXs"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
-              aria-owns="hds-select-1-menu"
-              class="Select-module_button__1aIsm"
-              id="hds-select-1-toggle-button"
-              type="button"
-            >
-              <span
-                class="Select-module_buttonLabel__1fqu5"
-              >
-                Suomi (+358)
-              </span>
-              <svg
-                aria-hidden="true"
-                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
-                role="img"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fill-rule="evenodd"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                  />
-                  <path
-                    d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-                    fill="currentColor"
-                  />
-                </g>
-              </svg>
-            </button>
-            <ul
-              aria-labelledby="hds-select-1-label"
-              aria-required="true"
-              class="Select-module_menu__1H2aU"
-              id="hds-select-1-menu"
-              role="listbox"
-              style="max-height: 260px;"
-              tabindex="-1"
-            />
-          </div>
-        </div>
-        <div
-          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-        >
-          <label
-            class="FieldLabel-module_label__1zrXK "
-            for="phone"
-          >
-            Puhelinnumero
-            <span
-              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-            >
-               
-              *
-            </span>
-          </label>
-          <div
-            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-          >
-            <input
-              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-              id="phone"
-              placeholder="Esim. 401234567"
-              required=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="IBAN"
-        >
-          Pankkitilinumero (IBAN)
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="IBAN"
-            placeholder="Esim. FI9780001700903330"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-fileinput"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="rectificationAttachments"
-        >
-          Liitetiedostot
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <div
-            class="FileInput-module_fileInputContainer__9N5TG"
-          >
-            <div
-              aria-hidden="true"
-              class="FileInput-module_dragAndDrop__3d3xe"
-            >
-              <div
-                class="FileInput-module_dragAndDropLabel__1pDQN"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <g
-                    fill="none"
-                    fill-rule="evenodd"
-                  >
-                    <path
-                      d="M0 0h24v24H0z"
-                    />
-                    <path
-                      d="M12 1.636l5.657 5.657-1.414 1.414L13 5.465V18h-2V5.465L7.757 8.707 6.343 7.293 12 1.636zM5 15v5h14v-5h2v7H3v-7h2z"
-                      fill="currentColor"
-                    />
-                  </g>
-                </svg>
-                <span
-                  class="FileInput-module_dragAndDropLabelText__3AJ4P"
-                >
-                  Raahaa tiedostot tähän
-                </span>
-              </div>
-            </div>
-            <div
-              class="FileInput-module_dragAndDropHelperText__31Ljw"
-            >
-              tai valitse tiedostot laitteeltasi
-            </div>
-            <div
-              class="FileInput-module_fileInputWrapper__1E8Jf"
-            >
-              <button
-                aria-hidden="true"
-                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  aria-hidden="true"
-                  class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fill-rule="evenodd"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                      />
-                      <path
-                        d="M13 6v5h5v2h-5v5h-2v-5H6v-2h5V6z"
-                        fill="currentColor"
-                      />
-                    </g>
-                  </svg>
-                </div>
-                <span
-                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
-                >
-                  Lisää tiedostoja
-                </span>
-              </button>
-              <input
-                accept=".png, .jpg, .pdf"
-                aria-describedby="rectificationAttachments-helper rectificationAttachments-info"
-                class="FileInput-module_fileInput__hClRc"
-                id="rectificationAttachments"
-                multiple=""
-                type="file"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="TextInput-module_infoText__zHOGs text-input_hds-text-input__info-text__3bqzy"
-          id="rectificationAttachments-info"
-        >
-          Yhtään tiedostoa ei ole valittu.
-        </div>
-        <div
-          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
-          id="rectificationAttachments-helper"
-        >
-          Vain .png,  .jpg ja  .pdf tiedostoja.
-        </div>
-      </div>
-      <ul
-        aria-label="Yhtään tiedostoa ei ole valittu."
-        class="FileInput-module_fileList__drFD1"
-        id="rectificationAttachments-list"
-        tabindex="-1"
-      />
-      <fieldset
-        class="SelectionGroup-module_selectionGroup__6Jxu8 rectification-decision-choice"
-      >
-        <legend
-          class="SelectionGroup-module_label__qlluz"
-        >
-          Haluan päätöksen
-           
-          <span
-            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-          >
-             
-            *
-          </span>
-        </legend>
-        <div
-          class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
-        >
-          <div>
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-            >
-              <input
-                checked=""
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="toParkingService"
-                type="radio"
-                value="toParkingService"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="toParkingService"
-              >
-                Pysäköinnin asiointikansiooni
-              </label>
-            </div>
-          </div>
-          <div>
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
-            >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="byMail"
-                type="radio"
-                value="byMail"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="byMail"
-              >
-                Kirjeitse antamaani osoitteeseen
-              </label>
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Component in moved car form matches snapshot 1`] = `
 <div>
   <p>
@@ -1663,6 +893,850 @@ exports[`Component in moved car form matches snapshot 1`] = `
           </div>
         </div>
       </fieldset>
+    </div>
+    <div>
+      <button
+        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS rectification-draft-button"
+        type="button"
+      >
+        <div
+          aria-hidden="true"
+          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+        >
+          <svg
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M7.5,12 L12,7.5 L16.5,12 L15,13.5 L13,11.5 L13,22 L11,22 L11,11.5 L9,13.5 L7.5,12 Z M11.5,2 C14.0570069,2 16.3672564,3.55157482 17.2358321,5.93092178 L17.2835,6.0665 L17.4145183,6.08731097 C20.0449239,6.53520702 21.9316381,8.61876864 21.9981819,11.350367 L22,11.5 C22,14.6411668 19.7996323,16.9265021 16.7006468,16.998261 L16.55,17 L15.5,17 L15.5,15 L16.55,15 C18.6163623,15 20,13.5942857 20,11.5 C20,9.538055 18.6018237,8.11877635 16.6000787,8.00507103 L16.4714957,7.99959367 L15.6755756,7.97689732 L15.5194193,7.19611614 C15.1395428,5.29673328 13.433695,4 11.5,4 C9.26285888,4 7.62213728,5.5585359 7.5065992,7.75063225 L7.50156899,7.88030287 L7.48772078,8.99175409 L6.33061979,9.0012438 C4.84064582,9.04438683 3.6,10.4529679 3.6,12.1 C3.6,13.6643787 4.83868693,14.9394465 6.38876321,14.9979059 L6.5,15 L8.5,15 L8.5,17 L6.5,17 C3.79380473,17 1.6,14.8061953 1.6,12.1 C1.6,9.68983052 3.25231852,7.56452435 5.49502278,7.09571076 L5.5645,7.082 L5.58684851,6.93675031 C6.05502185,4.09688845 8.36434526,2.06966277 11.3452237,2.00175907 L11.5,2 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+        <span
+          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+        >
+          Tallenna keskeneräisenä
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component in parking fine appeal form matches snapshot 1`] = `
+<div>
+  <p>
+    Pakolliset kentät on merkitty tähdellä *
+  </p>
+  <div>
+    <div
+      class="rectification-info-container"
+    >
+      <div
+        class="rectification-user-section"
+      >
+        <fieldset
+          class="SelectionGroup-module_selectionGroup__6Jxu8"
+        >
+          <legend
+            class="SelectionGroup-module_label__qlluz"
+          >
+            Olen ajoneuvon *
+             
+          </legend>
+          <div
+            class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
+          >
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  checked=""
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="driver"
+                  type="radio"
+                  value="driver"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="driver"
+                >
+                  Kuljettaja
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="owner"
+                  type="radio"
+                  value="owner"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="owner"
+                >
+                  Omistaja
+                </label>
+              </div>
+            </div>
+            <div>
+              <div
+                class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              >
+                <input
+                  class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                  id="holder"
+                  type="radio"
+                  value="holder"
+                />
+                <label
+                  class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                  for="holder"
+                >
+                  Haltija
+                </label>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+        <div
+          class="rectification-form-user-details "
+        >
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="fullName"
+            >
+              Nimi *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="fullName"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="ssn"
+            >
+              Henkilötunnus *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="ssn"
+                readonly=""
+                type="text"
+                value="123456-789A"
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="email"
+            >
+              Sähköpostiosoite *
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="email"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <svg
+            aria-label="Tieto haettu Helsinki-profiilista"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <hr />
+    <p>
+      <svg
+        aria-hidden="true"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <rect
+            height="24"
+            width="24"
+          />
+          <path
+            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+            fill="currentColor"
+          />
+        </g>
+      </svg>
+      Merkityt tiedot on haettu Helsinki-profiilistasi.
+      <a
+        aria-label="Siirry Helsinki-profiiliin muokataksesi tietoja. Avautuu uudessa välilehdessä. Avaa toisen verkkosivun."
+        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F"
+        href="https://profiili.test.kuva.hel.ninja"
+        rel="noopener"
+        target="_blank"
+      >
+        Siirry Helsinki-profiiliin muokataksesi tietoja.
+        <svg
+          aria-hidden="true"
+          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Link-module_icon__3ReCc link_icon__i_HqN Link-module_verticalAlignSmallOrMediumIcon__3FOVU link_vertical-align-small-or-medium-icon__25J0G"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M0 0h24v24H0z"
+            />
+            <path
+              d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+      </a>
+    </p>
+    <div
+      class="rectification-form-container"
+    >
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-textarea"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="rectification-content"
+        >
+          Oikaisuvaatimuksen sisältö
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <textarea
+            aria-describedby="rectification-content-helper"
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="rectification-content"
+            required=""
+          />
+        </div>
+        
+        <div
+          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
+          id="rectification-content-helper"
+        >
+          0/2500
+        </div>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="newEmail"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="newEmail"
+        >
+          Haluan ilmoitukset asian käsittelystä eri sähköpostiosoitteeseen
+        </label>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="newEmailAddress"
+        >
+          Sähköpostiosoite *
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            disabled=""
+            id="newEmailAddress"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="newEmailConfirm"
+        >
+          Kirjoita sähköpostiosoite uudelleen
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            disabled=""
+            id="newEmailConfirm"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="address"
+        >
+          Osoite
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="address"
+            placeholder="Esim. Elimäenkatu 5"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="rectification-subgrid"
+      >
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="zipCode"
+          >
+            Postinumero
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="zipCode"
+              placeholder="Esim. 00100"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="city"
+          >
+            Postitoimipaikka
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="city"
+              placeholder="Esim. Helsinki"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="Select-module_root__Ka5uO"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="hds-select-1-toggle-button"
+            id="hds-select-1-label"
+          >
+            Maakoodi
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="Select-module_wrapper__1WQXs"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
+              aria-owns="hds-select-1-menu"
+              class="Select-module_button__1aIsm"
+              id="hds-select-1-toggle-button"
+              type="button"
+            >
+              <span
+                class="Select-module_buttonLabel__1fqu5"
+              >
+                Suomi (+358)
+              </span>
+              <svg
+                aria-hidden="true"
+                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                  />
+                  <path
+                    d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                    fill="currentColor"
+                  />
+                </g>
+              </svg>
+            </button>
+            <ul
+              aria-labelledby="hds-select-1-label"
+              aria-required="true"
+              class="Select-module_menu__1H2aU"
+              id="hds-select-1-menu"
+              role="listbox"
+              style="max-height: 260px;"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="phone"
+          >
+            Puhelinnumero
+            <span
+              class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="phone"
+              placeholder="Esim. 401234567"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="IBAN"
+        >
+          Pankkitilinumero (IBAN)
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="IBAN"
+            placeholder="Esim. FI9780001700903330"
+            required=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq rectification-fileinput"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="rectificationAttachments"
+        >
+          Liitetiedostot
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <div
+            class="FileInput-module_fileInputContainer__9N5TG"
+          >
+            <div
+              aria-hidden="true"
+              class="FileInput-module_dragAndDrop__3d3xe"
+            >
+              <div
+                class="FileInput-module_dragAndDropLabel__1pDQN"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                    />
+                    <path
+                      d="M12 1.636l5.657 5.657-1.414 1.414L13 5.465V18h-2V5.465L7.757 8.707 6.343 7.293 12 1.636zM5 15v5h14v-5h2v7H3v-7h2z"
+                      fill="currentColor"
+                    />
+                  </g>
+                </svg>
+                <span
+                  class="FileInput-module_dragAndDropLabelText__3AJ4P"
+                >
+                  Raahaa tiedostot tähän
+                </span>
+              </div>
+            </div>
+            <div
+              class="FileInput-module_dragAndDropHelperText__31Ljw"
+            >
+              tai valitse tiedostot laitteeltasi
+            </div>
+            <div
+              class="FileInput-module_fileInputWrapper__1E8Jf"
+            >
+              <button
+                aria-hidden="true"
+                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  aria-hidden="true"
+                  class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M13 6v5h5v2h-5v5h-2v-5H6v-2h5V6z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </div>
+                <span
+                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                >
+                  Lisää tiedostoja
+                </span>
+              </button>
+              <input
+                accept=".png, .jpg, .pdf"
+                aria-describedby="rectificationAttachments-helper rectificationAttachments-info"
+                class="FileInput-module_fileInput__hClRc"
+                id="rectificationAttachments"
+                multiple=""
+                type="file"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="TextInput-module_infoText__zHOGs text-input_hds-text-input__info-text__3bqzy"
+          id="rectificationAttachments-info"
+        >
+          Yhtään tiedostoa ei ole valittu.
+        </div>
+        <div
+          class="TextInput-module_helperText__2dLR6 text-input_hds-text-input__helper-text__3V2KM"
+          id="rectificationAttachments-helper"
+        >
+          Vain .png,  .jpg ja  .pdf tiedostoja.
+        </div>
+      </div>
+      <ul
+        aria-label="Yhtään tiedostoa ei ole valittu."
+        class="FileInput-module_fileList__drFD1"
+        id="rectificationAttachments-list"
+        tabindex="-1"
+      />
+      <fieldset
+        class="SelectionGroup-module_selectionGroup__6Jxu8 rectification-decision-choice"
+      >
+        <legend
+          class="SelectionGroup-module_label__qlluz"
+        >
+          Haluan päätöksen
+           
+          <span
+            class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+          >
+             
+            *
+          </span>
+        </legend>
+        <div
+          class="SelectionGroup-module_items__28m_S SelectionGroup-module_vertical__3iorC"
+        >
+          <div>
+            <div
+              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            >
+              <input
+                checked=""
+                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                id="toParkingService"
+                type="radio"
+                value="toParkingService"
+              />
+              <label
+                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                for="toParkingService"
+              >
+                Pysäköinnin asiointikansiooni
+              </label>
+            </div>
+          </div>
+          <div>
+            <div
+              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            >
+              <input
+                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+                id="byMail"
+                type="radio"
+                value="byMail"
+              />
+              <label
+                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+                for="byMail"
+              >
+                Kirjeitse antamaani osoitteeseen
+              </label>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div>
+      <button
+        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS rectification-draft-button"
+        type="button"
+      >
+        <div
+          aria-hidden="true"
+          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+        >
+          <svg
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M7.5,12 L12,7.5 L16.5,12 L15,13.5 L13,11.5 L13,22 L11,22 L11,11.5 L9,13.5 L7.5,12 Z M11.5,2 C14.0570069,2 16.3672564,3.55157482 17.2358321,5.93092178 L17.2835,6.0665 L17.4145183,6.08731097 C20.0449239,6.53520702 21.9316381,8.61876864 21.9981819,11.350367 L22,11.5 C22,14.6411668 19.7996323,16.9265021 16.7006468,16.998261 L16.55,17 L15.5,17 L15.5,15 L16.55,15 C18.6163623,15 20,13.5942857 20,11.5 C20,9.538055 18.6018237,8.11877635 16.6000787,8.00507103 L16.4714957,7.99959367 L15.6755756,7.97689732 L15.5194193,7.19611614 C15.1395428,5.29673328 13.433695,4 11.5,4 C9.26285888,4 7.62213728,5.5585359 7.5065992,7.75063225 L7.50156899,7.88030287 L7.48772078,8.99175409 L6.33061979,9.0012438 C4.84064582,9.04438683 3.6,10.4529679 3.6,12.1 C3.6,13.6643787 4.83868693,14.9394465 6.38876321,14.9979059 L6.5,15 L8.5,15 L8.5,17 L6.5,17 C3.79380473,17 1.6,14.8061953 1.6,12.1 C1.6,9.68983052 3.25231852,7.56452435 5.49502278,7.09571076 L5.5645,7.082 L5.58684851,6.93675031 C6.05502185,4.09688845 8.36434526,2.06966277 11.3452237,2.00175907 L11.5,2 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+        <span
+          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+        >
+          Tallenna keskeneräisenä
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -159,9 +159,9 @@
         "holder": "Haltija"
       },
       "moved-car": {
-        "relation": "Teen oikaisuvaatimuksen ajoneuvon *",
-        "driver": "Kuljettajana",
-        "owner": "Omistajana",
+        "relation": "Teen oikaisuvaatimuksen *",
+        "driver": "Ajoneuvon kuljettajana",
+        "owner": "Ajoneuvon omistajana",
         "poa-holder": "Valtakirjalla"
       }
     },
@@ -177,7 +177,8 @@
     "decision-choice": "Haluan päätöksen",
     "toParkingService": "Pysäköinnin asiointikansiooni",
     "byMail": "Kirjeitse antamaani osoitteeseen",
-    "attachments": "Liitetiedostot"
+    "attachments": "Liitetiedostot",
+    "attach-poa": "Liitä valtakirja"
   },
   "imageViewer": {
     "header": "Pysäköintivirhemaksun kuvat",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -151,10 +151,20 @@
     "submit": "Lähetä"
   },
   "rectification": {
-    "relation": "Olen ajoneuvon *",
-    "driver": "Kuljettaja",
-    "owner": "Omistaja",
-    "holder": "Haltija",
+    "relation-info": {
+      "parking-fine": {
+        "relation": "Olen ajoneuvon *",
+        "driver": "Kuljettaja",
+        "owner": "Omistaja",
+        "holder": "Haltija"
+      },
+      "moved-car": {
+        "relation": "Teen oikaisuvaatimuksen ajoneuvon *",
+        "driver": "Kuljettajana",
+        "owner": "Omistajana",
+        "poa-holder": "Valtakirjalla"
+      }
+    },
     "rectification-content": "Oikaisuvaatimuksen sisältö",
     "description-over-limit": "Kuvaus ylittää merkkimäärän",
     "to-separate-email": "Haluan ilmoitukset asian käsittelystä eri sähköpostiosoitteeseen",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -8,6 +8,7 @@
     "fetched-from-profile-aria": "Tieto haettu Helsinki-profiilista",
     "previous": "Edellinen",
     "next": "Seuraava",
+    "save-draft": "Tallenna keskeneräisenä",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",
@@ -17,6 +18,12 @@
       "copy-barcode": "Kopioi virtuaaliviivakoodi",
       "toast-label": "Kopioitu leikepöydälle!",
       "toast-body": "Virtuaaliviivakoodi kopioitu leikepöydälle"
+    },
+    "notifications": {
+      "draft-saved": {
+        "label": "Lomake tallennettu",
+        "text": "Lomake tallennettu keskeneräisenä onnistuneesti."
+      }
     },
     "aria": {
       "open-external": "Avaa toisen verkkosivun.",


### PR DESCRIPTION
This PR:
* Adds fileinput for uploading power of attorney file to moved car form
* Changes the first radio button texts on moved car form to comply with the designs
* Adds "Save as draft" button to all views using rectification form

The POA file input should also be responsive, that is why there are quite many changes on styling.
Most of the added lines are from a new snapshot about rectification view of moved car appeal form, which was added since there were some differences to the existing one.

File input:
<img width="1244" alt="Screenshot 2022-12-01 at 17 52 09" src="https://user-images.githubusercontent.com/36920208/205113958-47b37a20-bf19-493a-9ab6-9dbc4e1dd742.png">

Button and notification (that wasn't on the design but probably still needed):
<img width="1074" alt="Screenshot 2022-12-01 at 19 01 22" src="https://user-images.githubusercontent.com/36920208/205114262-506923cc-b0f9-40f9-be0e-43a009dedb66.png">

