### PR TITLE
Add dividers to parking fine summary

### DIFF
--- a/src/components/barcode/Barcode.tsx
+++ b/src/components/barcode/Barcode.tsx
@@ -23,7 +23,7 @@ const Barcode = (props: BarcodeProps) => {
     <>
       <div
         className={`barcode-container ${
-          className !== undefined ? className : ''
+          className ? className : ''
         }`}>
         <TextInput
           id="barCode"

--- a/src/components/barcode/Barcode.tsx
+++ b/src/components/barcode/Barcode.tsx
@@ -6,10 +6,11 @@ import { useTranslation } from 'react-i18next';
 
 type BarcodeProps = {
   barcode: string;
+  className?: string;
 };
 
 const Barcode = (props: BarcodeProps) => {
-  const { barcode } = props;
+  const { barcode, className } = props;
   const { t } = useTranslation();
   const [copySuccess, setCopySuccess] = useState(false);
 
@@ -20,7 +21,10 @@ const Barcode = (props: BarcodeProps) => {
 
   return (
     <>
-      <div className="barcode-container">
+      <div
+        className={`barcode-container ${
+          className !== undefined ? className : ''
+        }`}>
         <TextInput
           id="barCode"
           label={t('common:barcode:label')}

--- a/src/components/barcode/__snapshots__/Barcode.test.tsx.snap
+++ b/src/components/barcode/__snapshots__/Barcode.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component matches snapshot 1`] = `
 <div>
   <div
-    class="barcode-container"
+    class="barcode-container "
   >
     <div
       class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"

--- a/src/components/parkingFineSummary/ParkingFineSummary.css
+++ b/src/components/parkingFineSummary/ParkingFineSummary.css
@@ -1,7 +1,7 @@
 .summary-container {
   display: grid;
   grid-template-columns: 510px auto auto;
-  grid-template-rows: repeat(6, 130px);
+  grid-auto-rows: auto;
   grid-gap: 12px 12px;
   margin-top: 50px;
 }
@@ -9,6 +9,10 @@
 .info-field {
   max-width: 384px;
   grid-row-end: auto;
+}
+
+.sum-field {
+  grid-column-end: 2;
 }
 
 .wide-field {
@@ -22,6 +26,13 @@ textarea {
 
 .vehicle-details-container {
   grid-column-start: 3;
-  grid-row-start: 1;
-  grid-row-end: 8;
+  grid-row: span 13;
+}
+
+hr {
+
+  height: 1px;
+  width: 100%;
+  grid-column-start: 1;
+  grid-column-end: span 2;
 }

--- a/src/components/parkingFineSummary/ParkingFineSummary.css
+++ b/src/components/parkingFineSummary/ParkingFineSummary.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: 510px auto auto;
   grid-auto-rows: auto;
-  grid-gap: 12px 12px;
+  grid-gap: 12px 24px;
   margin-top: 50px;
 }
 
@@ -29,10 +29,15 @@ textarea {
   grid-row: span 13;
 }
 
-hr {
+.vehicle-details-header {
+  font-weight: normal;
+  margin-bottom: 2rem;
+}
 
-  height: 1px;
+hr {
+  border: 1px solid var(--color-black-20);
   width: 100%;
+  margin-right: 24px;
   grid-column-start: 1;
   grid-column-end: span 2;
 }

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -30,7 +30,17 @@ const ParkingFineSummary = (): React.ReactElement => {
   return (
     <>
       <div data-testid="parkingFineSummary" className="summary-container">
-        <Card className="vehicle-details-container" border>
+        <Card
+          className="vehicle-details-container"
+          border
+          theme={{
+            '--border-color': 'var(--color-black-20)',
+            '--padding-horizontal': 'var(--spacing-l)',
+            '--padding-vertical': 'var(--spacing-m)'
+          }}>
+          <h2 className="vehicle-details-header">
+            {t('parking-fine:vehicle-info:header')}
+          </h2>
           <TextInput
             id="regNumber"
             label={t('common:fine-info:reg-number:label')}

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -79,6 +79,8 @@ const ParkingFineSummary = (): React.ReactElement => {
           readOnly
         />
 
+        <hr />
+
         <TextInput
           className="info-field"
           id="address"
@@ -93,6 +95,8 @@ const ParkingFineSummary = (): React.ReactElement => {
           value={t('common:fine-info:additional-details:placeholder')}
           readOnly
         />
+
+        <hr />
 
         <TextArea
           className="info-field"
@@ -123,6 +127,8 @@ const ParkingFineSummary = (): React.ReactElement => {
           readOnly
         />
 
+        <hr />
+
         <TextArea
           className="wide-field"
           id="fineAdditionalDetails"
@@ -130,12 +136,15 @@ const ParkingFineSummary = (): React.ReactElement => {
           value={t('common:fine-info:fine-additional-details:placeholder')}
           readOnly
         />
+
+        <hr />
+
         <TextInput
           id="sum"
           label={t('common:fine-info:sum:label')}
           value={t('common:fine-info:sum:placeholder')}
           readOnly
-          className="info-field"
+          className="info-field sum-field"
         />
         <TextInput
           className="info-field"
@@ -144,9 +153,13 @@ const ParkingFineSummary = (): React.ReactElement => {
           value={t('common:fine-info:due-date:placeholder')}
           readOnly
         />
-      </div>
 
-      <Barcode barcode="430123730001230560012400000000000000000100018714210302" />
+        <hr />
+        <Barcode
+          barcode="430123730001230560012400000000000000000100018714210302"
+          className="wide-field"
+        />
+      </div>
     </>
   );
 };

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -7,9 +7,14 @@ exports[`Component matches snapshot 1`] = `
     data-testid="parkingFineSummary"
   >
     <div
-      class="Card-module_card__1WbKx card_hds-card--border__c2dBc vehicle-details-container"
+      class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
       role="region"
     >
+      <h2
+        class="vehicle-details-header"
+      >
+        Ajoneuvon tiedot
+      </h2>
       <div
         class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
       >

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -189,6 +189,7 @@ exports[`Component matches snapshot 1`] = `
         />
       </div>
     </div>
+    <hr />
     <div
       class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
     >
@@ -231,6 +232,7 @@ exports[`Component matches snapshot 1`] = `
         />
       </div>
     </div>
+    <hr />
     <div
       class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
     >
@@ -315,6 +317,7 @@ exports[`Component matches snapshot 1`] = `
         />
       </div>
     </div>
+    <hr />
     <div
       class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
     >
@@ -336,8 +339,9 @@ exports[`Component matches snapshot 1`] = `
         </textarea>
       </div>
     </div>
+    <hr />
     <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
     >
       <label
         class="FieldLabel-module_label__1zrXK "
@@ -378,67 +382,68 @@ exports[`Component matches snapshot 1`] = `
         />
       </div>
     </div>
-  </div>
-  <div
-    class="barcode-container"
-  >
+    <hr />
     <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="barCode"
-      >
-        Virtuaaliviivakoodi
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="barCode"
-          readonly=""
-          type="text"
-          value="430123730001230560012400000000000000000100018714210302"
-        />
-      </div>
-    </div>
-    <button
-      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
-      data-testid="copy-to-clipboard"
-      type="button"
+      class="barcode-container wide-field"
     >
       <div
-        aria-hidden="true"
-        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
       >
-        <svg
-          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="barCode"
         >
-          <g
-            fill="none"
-            fill-rule="evenodd"
-          >
-            <rect
-              height="24"
-              width="24"
-            />
-            <path
-              d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
+          Virtuaaliviivakoodi
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="barCode"
+            readonly=""
+            type="text"
+            value="430123730001230560012400000000000000000100018714210302"
+          />
+        </div>
       </div>
-      <span
-        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      <button
+        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
+        data-testid="copy-to-clipboard"
+        type="button"
       >
-        Kopioi virtuaaliviivakoodi
-      </span>
-    </button>
+        <div
+          aria-hidden="true"
+          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+        >
+          <svg
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <rect
+                height="24"
+                width="24"
+              />
+              <path
+                d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+        <span
+          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+        >
+          Kopioi virtuaaliviivakoodi
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -88,6 +88,7 @@
     "to-payment": "Maksamaan",
     "submit-success": "Lähetys onnistui",
     "vehicle-info": {
+      "header": "Ajoneuvon tiedot",
       "type": {
         "label": "Ajoneuvolaji",
         "placeholder": "Henkilöauto M1"


### PR DESCRIPTION
This PR:
- Adds dividers to parking fine summary
- Fixes some stylings
- Adds optional className property to Barcode component

![Screenshot 2022-12-02 at 13 24 27](https://user-images.githubusercontent.com/84900656/205282234-491e545b-fb04-4ae9-953d-707f6defd112.png)
