### PR TITLE
Update email confirmation text style

### DIFF
--- a/src/components/extendDueDate/ExtendDueDate.test.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.test.tsx
@@ -94,6 +94,15 @@ describe('extend due date form', () => {
       });
       expect(infoNotification).toBeInTheDocument();
 
+      // Email confirmation text is visible
+      const emailConfirmationLabel = screen.getByText(/Sähköpostivahvistus/i);
+      expect(emailConfirmationLabel).toBeInTheDocument();
+
+      const emailConfirmationText = screen.getByText(
+        /Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen:/i
+      );
+      expect(emailConfirmationText).toBeInTheDocument();
+
       // Checkbox is visible and clickable
       const checkbox = screen.getByRole('checkbox', {
         name: t('common:email-confirmation')
@@ -105,12 +114,6 @@ describe('extend due date form', () => {
         checkbox.click();
       });
       expect(checkbox).toBeChecked();
-
-      // Email confirmation notification is visible
-      const emailInfoNotification = screen.getByRole('heading', {
-        name: t('due-date:notifications:email-confirmation:label')
-      });
-      expect(emailInfoNotification).toBeInTheDocument();
     });
   });
 });

--- a/src/components/extendDueDate/ExtendDueDateForm.css
+++ b/src/components/extendDueDate/ExtendDueDateForm.css
@@ -12,3 +12,8 @@
 .email-notification {
   margin-top: 24px;
 }
+
+.email-confirmation-label {
+  font-size: var(--fontsize-body-m);
+  font-weight: 500;
+}

--- a/src/components/extendDueDate/ExtendDueDateForm.css
+++ b/src/components/extendDueDate/ExtendDueDateForm.css
@@ -1,19 +1,18 @@
 .form-body {
-  margin: 50px 0 12px;
+  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-xs);
 }
 
 .info-container {
   display: grid;
   grid-template-columns: auto auto auto;
   grid-gap: 12px 12px;
-  margin-top: 24px;
-}
-
-.email-notification {
-  margin-top: 24px;
+  margin-top: var(--spacing-m);
+  margin-bottom: var(--spacing-m);
 }
 
 .email-confirmation-label {
   font-size: var(--fontsize-body-m);
   font-weight: 500;
+  margin-top: var(--spacing-l);
 }

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -26,7 +26,6 @@ const ExtendDueDateForm = (): React.ReactElement => {
   const newDueDate = formatDate(dueDateFormValues.newDueDate);
   const extensionAllowed = isExtensionAllowed(dueDateFormValues.dueDate);
   const [infoNotificationOpen, setInfoNotificationOpen] = useState(false);
-  const [emailNotificationOpen, setEmailNotificationOpen] = useState(true);
 
   const handleCheckedChange = () => {
     dispatch(
@@ -96,6 +95,23 @@ const ExtendDueDateForm = (): React.ReactElement => {
 
       <Barcode barcode="43012383000123056001240000000000000000018714210302" />
 
+      <p className="email-confirmation-label">
+        {t('due-date:notifications:email-confirmation:label')}
+      </p>
+      <p>
+        {t('due-date:notifications:email-confirmation:text', {
+          email: user?.email
+        })}{' '}
+        <Link
+          href={window._env_.REACT_APP_PROFILE_UI_URL}
+          size="M"
+          external
+          openInNewTab
+          openInExternalDomainAriaLabel={t('common:aria:open-external')}
+          openInNewTabAriaLabel={t('common:aria:open-new-tab')}>
+          {t('common:helsinki-profile-link')}
+        </Link>
+      </p>
       <Checkbox
         label={t('common:email-confirmation')}
         id="emailConfirmationCheckbox"
@@ -103,28 +119,6 @@ const ExtendDueDateForm = (): React.ReactElement => {
         onChange={handleCheckedChange}
         disabled={!extensionAllowed || formContent.formSubmitted}
       />
-      {emailNotificationOpen && (
-        <Notification
-          className="email-notification"
-          size="small"
-          label={t('due-date:notifications:email-confirmation:label')}
-          dismissible
-          closeButtonLabelText="Close notification"
-          onClose={() => setEmailNotificationOpen(false)}>
-          {t('due-date:notifications:email-confirmation:text', {
-            email: user?.email
-          })}
-          <Link
-            href={window._env_.REACT_APP_PROFILE_UI_URL}
-            size="S"
-            external
-            openInNewTab
-            openInExternalDomainAriaLabel={t('common:aria:open-external')}
-            openInNewTabAriaLabel={t('common:aria:open-new-tab')}>
-            {t('common:helsinki-profile-link')}
-          </Link>
-        </Notification>
-      )}
     </div>
   );
 };

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -130,7 +130,7 @@
         "label": "Et voi siirtää eräpäivää"
       },
       "email-confirmation": {
-        "label": "Saat vahvistuksen sähköpostilla",
+        "label": "Sähköpostivahvistus",
         "text": "Vahvistus lähetetään Helsinki-profiilissasi olevaan sähköpostiosoitteeseen: {{email}}. "
       },
       "success": {


### PR DESCRIPTION
This PR:
* Changes the email confirmation text of ExtendDueDateForm from notification to just text
* Adds some spacing to the page to improve styling

![Screenshot 2022-12-02 at 14 24 46](https://user-images.githubusercontent.com/36920208/205292800-78855840-86ff-4e8d-93a4-8c1a811f1402.png)
