### PR TITLE
Add reimbursement summary

### DIFF
--- a/src/components/carInfoCard/CarInfoCard.css
+++ b/src/components/carInfoCard/CarInfoCard.css
@@ -1,0 +1,8 @@
+.vehicle-details-container {
+  flex: 1 1;
+}
+
+.vehicle-details-header {
+  font-weight: normal;
+  margin-bottom: 2rem;
+}

--- a/src/components/carInfoCard/CarInfoCard.tsx
+++ b/src/components/carInfoCard/CarInfoCard.tsx
@@ -14,6 +14,7 @@ const CarInfoCard = (): React.ReactElement => {
 
   return (
     <Card
+      data-testid="carInfoCard"
       className="vehicle-details-container"
       border
       theme={{

--- a/src/components/carInfoCard/CarInfoCard.tsx
+++ b/src/components/carInfoCard/CarInfoCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import ImageViewer from '../imageViewer/ImageViewer';
+import './CarInfoCard.css';
 
 const CarInfoCard = (): React.ReactElement => {
   const { t } = useTranslation();

--- a/src/components/carInfoCard/CarInfoCard.tsx
+++ b/src/components/carInfoCard/CarInfoCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Card, TextInput } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import ImageViewer from '../imageViewer/ImageViewer';
+
+const CarInfoCard = (): React.ReactElement => {
+  const { t } = useTranslation();
+
+  const imageUrls = [
+    'https://via.placeholder.com/600.png',
+    'https://via.placeholder.com/600x1200.png',
+    'https://via.placeholder.com/1200x800.png'
+  ];
+
+  return (
+    <Card
+      className="vehicle-details-container"
+      border
+      theme={{
+        '--border-color': 'var(--color-black-20)',
+        '--padding-horizontal': 'var(--spacing-l)',
+        '--padding-vertical': 'var(--spacing-m)'
+      }}>
+      <h2 className="vehicle-details-header">
+        {t('parking-fine:vehicle-info:header')}
+      </h2>
+      <TextInput
+        id="regNumber"
+        label={t('common:fine-info:reg-number:label')}
+        value={t('common:fine-info:reg-number:placeholder')}
+        readOnly
+      />
+      <TextInput
+        id="vehicleType"
+        label={t('parking-fine:vehicle-info:type:label')}
+        value={t('parking-fine:vehicle-info:type:placeholder')}
+        readOnly
+      />
+      <TextInput
+        id="vehicleBrand"
+        label={t('parking-fine:vehicle-info:brand:label')}
+        value={t('parking-fine:vehicle-info:brand:placeholder')}
+        readOnly
+      />
+      <TextInput
+        id="vehicleModel"
+        label={t('parking-fine:vehicle-info:model:label')}
+        value={t('parking-fine:vehicle-info:model:placeholder')}
+        readOnly
+      />
+      <TextInput
+        id="vehicleColor"
+        label={t('parking-fine:vehicle-info:color:label')}
+        value={t('parking-fine:vehicle-info:color:placeholder')}
+        readOnly
+      />
+      <ImageViewer images={imageUrls} />
+    </Card>
+  );
+};
+
+export default CarInfoCard;

--- a/src/components/formContent/FormContent.test.tsx
+++ b/src/components/formContent/FormContent.test.tsx
@@ -37,6 +37,16 @@ const parkingFineFormContentSliceMock = createSlice({
   reducers: {}
 });
 
+const movedCarFormContentSliceMock = createSlice({
+  name: 'formContent',
+  initialState: {
+    formSubmitted: false,
+    selectedForm: 'moved-car',
+    submitDisabled: true
+  },
+  reducers: {}
+});
+
 describe('form content', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
@@ -78,6 +88,20 @@ describe('form content', () => {
         );
         await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
       });
+
+      test('moved car appeal form', async () => {
+        const store = configureStore({
+          reducer: {
+            formContent: movedCarFormContentSliceMock.reducer
+          }
+        });
+        const { getByTestId } = render(
+          <Provider store={store}>
+            <FormContent activeStep={0} />
+          </Provider>
+        );
+        await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
+      });
     });
     describe('step 2 of', () => {
       test('extend due date form', async () => {
@@ -98,6 +122,7 @@ describe('form content', () => {
           expect(getByTestId('extendDueDateForm')).toBeVisible()
         );
       });
+
       test('parking fine appeal form', async () => {
         const store = configureStore({
           reducer: {
@@ -113,6 +138,22 @@ describe('form content', () => {
 
         await waitFor(() =>
           expect(getByTestId('parkingFineSummary')).toBeVisible()
+        );
+      });
+
+      test('moved car appeal form', async () => {
+        const store = configureStore({
+          reducer: {
+            formContent: movedCarFormContentSliceMock.reducer
+          }
+        });
+        const { getByTestId } = render(
+          <Provider store={store}>
+            <FormContent activeStep={1} />
+          </Provider>
+        );
+        await waitFor(() =>
+          expect(getByTestId('reimbursementSummary')).toBeVisible()
         );
       });
     });

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -4,9 +4,8 @@ import SearchForm from '../searchForm/SearchForm';
 import { FormId, selectFormContent } from './formContentSlice';
 import './FormContent.css';
 import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
-import ParkingFineSummary from '../parkingFineSummary/ParkingFineSummary';
+import InfoContainer from '../infoContainer/InfoContainer';
 import RectificationForm from '../rectification/RectificationForm';
-import ReimbursementSummary from '../reimbursement/ReimbursementSummary';
 
 interface Props {
   activeStep: number;
@@ -20,9 +19,9 @@ const FormContent = (props: Props): React.ReactElement => {
       case 'due-date':
         return <ExtendDueDateForm />;
       case 'parking-fine':
-        return <ParkingFineSummary />;
+        return <InfoContainer />;
       case 'moved-car':
-        return <ReimbursementSummary />;
+        return <InfoContainer />;
     }
   };
 

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -6,6 +6,7 @@ import './FormContent.css';
 import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
 import ParkingFineSummary from '../parkingFineSummary/ParkingFineSummary';
 import RectificationForm from '../rectification/RectificationForm';
+import ReimbursementSummary from '../reimbursement/ReimbursementSummary';
 
 interface Props {
   activeStep: number;
@@ -20,6 +21,8 @@ const FormContent = (props: Props): React.ReactElement => {
         return <ExtendDueDateForm />;
       case 'parking-fine':
         return <ParkingFineSummary />;
+      case 'moved-car':
+        return <ReimbursementSummary />;
     }
   };
 

--- a/src/components/infoContainer/InfoContainer.css
+++ b/src/components/infoContainer/InfoContainer.css
@@ -1,0 +1,21 @@
+.info-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-m);
+  margin-top: var(--spacing-xl);
+}
+
+.summary-container {
+  display: grid;
+  grid-template-columns: 60% auto;
+  grid-auto-rows: auto;
+  grid-gap: 12px 24px;
+}
+
+hr {
+  border: 1px solid var(--color-black-20);
+  width: 100%;
+  margin-right: 24px;
+  grid-column-start: 1;
+  grid-column-end: span 2;
+}

--- a/src/components/infoContainer/InfoContainer.test.tsx
+++ b/src/components/infoContainer/InfoContainer.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import InfoContainer from './InfoContainer';
+import { Provider } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import store from '../../store';
+import '@testing-library/jest-dom';
+
+describe('info container', () => {
+  test('passes a11y validation', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <InfoContainer />
+      </Provider>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('renders parking fine summary correctly', async () => {
+    const parkingFineFormContentSliceMock = createSlice({
+      name: 'formContent',
+      initialState: {
+        formSubmitted: false,
+        selectedForm: 'parking-fine',
+        submitDisabled: true
+      },
+      reducers: {}
+    });
+    const store = configureStore({
+      reducer: {
+        formContent: parkingFineFormContentSliceMock.reducer
+      }
+    });
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <InfoContainer />
+      </Provider>
+    );
+
+    // Car info card is visible
+    await waitFor(() => expect(getByTestId('carInfoCard')).toBeVisible());
+
+    // ParkingFineSummary is visible
+    await waitFor(() =>
+      expect(getByTestId('parkingFineSummary')).toBeVisible()
+    );
+  });
+
+  test('renders reimbursement summary correctly', async () => {
+    const movedCarFormContentSliceMock = createSlice({
+      name: 'formContent',
+      initialState: {
+        formSubmitted: false,
+        selectedForm: 'moved-car',
+        submitDisabled: true
+      },
+      reducers: {}
+    });
+    const store = configureStore({
+      reducer: {
+        formContent: movedCarFormContentSliceMock.reducer
+      }
+    });
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <InfoContainer />
+      </Provider>
+    );
+
+    // Car info card is visible
+    await waitFor(() => expect(getByTestId('carInfoCard')).toBeVisible());
+
+    // ReimbursementSummary is visible
+    await waitFor(() =>
+      expect(getByTestId('reimbursementSummary')).toBeVisible()
+    );
+  });
+});

--- a/src/components/infoContainer/InfoContainer.tsx
+++ b/src/components/infoContainer/InfoContainer.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { FormId, selectFormContent } from '../formContent/formContentSlice';
+import CarInfoCard from '../carInfoCard/CarInfoCard';
+import ParkingFineSummary from '../parkingFineSummary/ParkingFineSummary';
+import ReimbursementSummary from '../reimbursement/ReimbursementSummary';
+import './InfoContainer.css';
+
+const InfoContainer = (): React.ReactElement => {
+  const selectedForm = useSelector(selectFormContent).selectedForm;
+
+  const selectForm = (selectedForm: FormId) => {
+    switch (selectedForm) {
+      case 'parking-fine':
+        return <ParkingFineSummary />;
+      case 'moved-car':
+        return <ReimbursementSummary />;
+    }
+  };
+  return (
+    <div className="info-container">
+      {selectForm(selectedForm)}
+      <CarInfoCard />
+    </div>
+  );
+};
+
+export default InfoContainer;

--- a/src/components/parkingFineSummary/ParkingFineSummary.css
+++ b/src/components/parkingFineSummary/ParkingFineSummary.css
@@ -1,9 +1,5 @@
-.summary-container {
-  display: grid;
-  grid-template-columns: 510px auto auto;
-  grid-auto-rows: auto;
-  grid-gap: 12px 24px;
-  margin-top: 50px;
+.summary-body {
+  flex: 2 1;
 }
 
 .info-field {
@@ -24,20 +20,3 @@ textarea {
   resize: none !important;
 }
 
-.vehicle-details-container {
-  grid-column-start: 3;
-  grid-row: span 13;
-}
-
-.vehicle-details-header {
-  font-weight: normal;
-  margin-bottom: 2rem;
-}
-
-hr {
-  border: 1px solid var(--color-black-20);
-  width: 100%;
-  margin-right: 24px;
-  grid-column-start: 1;
-  grid-column-end: span 2;
-}

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -1,27 +1,15 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Card, TextArea, TextInput } from 'hds-react';
+import { TextArea, TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { setSubmitDisabled } from '../formContent/formContentSlice';
 import './ParkingFineSummary.css';
 import Barcode from '../barcode/Barcode';
-import ImageViewer from '../imageViewer/ImageViewer';
-
-/**
- * TODO
- * - Add dividers
- * - Add image view to vehicle details
- */
+import CarInfoCard from '../carInfoCard/CarInfoCard';
 
 const ParkingFineSummary = (): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-
-  const imageUrls = [
-    'https://via.placeholder.com/600.png',
-    'https://via.placeholder.com/600x1200.png',
-    'https://via.placeholder.com/1200x800.png'
-  ];
 
   useEffect(() => {
     dispatch(setSubmitDisabled(false));
@@ -30,49 +18,7 @@ const ParkingFineSummary = (): React.ReactElement => {
   return (
     <>
       <div data-testid="parkingFineSummary" className="summary-container">
-        <Card
-          className="vehicle-details-container"
-          border
-          theme={{
-            '--border-color': 'var(--color-black-20)',
-            '--padding-horizontal': 'var(--spacing-l)',
-            '--padding-vertical': 'var(--spacing-m)'
-          }}>
-          <h2 className="vehicle-details-header">
-            {t('parking-fine:vehicle-info:header')}
-          </h2>
-          <TextInput
-            id="regNumber"
-            label={t('common:fine-info:reg-number:label')}
-            value={t('common:fine-info:reg-number:placeholder')}
-            readOnly
-          />
-          <TextInput
-            id="vehicleType"
-            label={t('parking-fine:vehicle-info:type:label')}
-            value={t('parking-fine:vehicle-info:type:placeholder')}
-            readOnly
-          />
-          <TextInput
-            id="vehicleBrand"
-            label={t('parking-fine:vehicle-info:brand:label')}
-            value={t('parking-fine:vehicle-info:brand:placeholder')}
-            readOnly
-          />
-          <TextInput
-            id="vehicleModel"
-            label={t('parking-fine:vehicle-info:model:label')}
-            value={t('parking-fine:vehicle-info:model:placeholder')}
-            readOnly
-          />
-          <TextInput
-            id="vehicleColor"
-            label={t('parking-fine:vehicle-info:color:label')}
-            value={t('parking-fine:vehicle-info:color:placeholder')}
-            readOnly
-          />
-          <ImageViewer images={imageUrls} />
-        </Card>
+        <CarInfoCard />
 
         <TextInput
           className="info-field"

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -3,9 +3,8 @@ import { useDispatch } from 'react-redux';
 import { TextArea, TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { setSubmitDisabled } from '../formContent/formContentSlice';
-import './ParkingFineSummary.css';
 import Barcode from '../barcode/Barcode';
-import CarInfoCard from '../carInfoCard/CarInfoCard';
+import './ParkingFineSummary.css';
 
 const ParkingFineSummary = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -16,10 +15,8 @@ const ParkingFineSummary = (): React.ReactElement => {
   }, [dispatch]);
 
   return (
-    <>
+    <div className="summary-body">
       <div data-testid="parkingFineSummary" className="summary-container">
-        <CarInfoCard />
-
         <TextInput
           className="info-field"
           id="fineTimeStamp"
@@ -116,7 +113,7 @@ const ParkingFineSummary = (): React.ReactElement => {
           className="wide-field"
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -3,452 +3,309 @@
 exports[`Component matches snapshot 1`] = `
 <div>
   <div
-    class="summary-container"
-    data-testid="parkingFineSummary"
+    class="summary-body"
   >
     <div
-      class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
-      data-testid="carInfoCard"
-      role="region"
+      class="summary-container"
+      data-testid="parkingFineSummary"
     >
-      <h2
-        class="vehicle-details-header"
-      >
-        Ajoneuvon tiedot
-      </h2>
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
       >
         <label
           class="FieldLabel-module_label__1zrXK "
-          for="regNumber"
+          for="fineTimeStamp"
         >
-          Ajoneuvon rekisteritunnus
+          Virheen ajankohta
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
         >
           <input
             class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="regNumber"
+            id="fineTimeStamp"
             readonly=""
             type="text"
-            value="Esim. ABC-123"
+            value="1.11.2019 09:41 - 1.11.2019 09:43"
           />
         </div>
       </div>
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
       >
         <label
           class="FieldLabel-module_label__1zrXK "
-          for="vehicleType"
+          for="refNumber"
         >
-          Ajoneuvolaji
+          Asianumero
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
         >
           <input
             class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="vehicleType"
+            id="refNumber"
             readonly=""
             type="text"
-            value="Henkilöauto M1"
+            value="Esim. 12345678"
           />
         </div>
       </div>
+      <hr />
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
       >
         <label
           class="FieldLabel-module_label__1zrXK "
-          for="vehicleBrand"
+          for="address"
         >
-          Merkki
+          Osoite
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
         >
           <input
             class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="vehicleBrand"
+            id="address"
             readonly=""
             type="text"
-            value="Citroen"
+            value="Näkinkuja 1c"
           />
         </div>
       </div>
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
       >
         <label
           class="FieldLabel-module_label__1zrXK "
-          for="vehicleModel"
+          for="additionalDetails"
         >
-          Malli
+          Lisätietoja
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
         >
           <input
             class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="vehicleModel"
+            id="additionalDetails"
             readonly=""
             type="text"
-            value="2D C2 HATCHBACK 1.4l-JMKFVC/232"
+            value="Kääntymispaikka"
           />
         </div>
       </div>
+      <hr />
       <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
       >
         <label
           class="FieldLabel-module_label__1zrXK "
-          for="vehicleColor"
+          for="fineTitle-1"
         >
-          Väri
+          Virhe
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
         >
-          <input
+          <textarea
             class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="vehicleColor"
+            id="fineTitle-1"
             readonly=""
-            type="text"
-            value="Punainen"
-          />
-        </div>
-      </div>
-      <div
-        class="imageViewer-preview-container"
-      >
-        <input
-          alt="Avaa kuvankatselu"
-          class="imageViewer-preview-image"
-          data-testid="clickable-image"
-          formmethod="dialog"
-          src="https://via.placeholder.com/600.png"
-          type="image"
-          value="0"
-        />
-        <input
-          alt="Avaa kuvankatselu"
-          class="imageViewer-preview-image"
-          data-testid="clickable-image"
-          formmethod="dialog"
-          src="https://via.placeholder.com/600x1200.png"
-          type="image"
-          value="1"
-        />
-        <input
-          alt="Avaa kuvankatselu"
-          class="imageViewer-preview-image"
-          data-testid="clickable-image"
-          formmethod="dialog"
-          src="https://via.placeholder.com/1200x800.png"
-          type="image"
-          value="2"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineTimeStamp"
-      >
-        Virheen ajankohta
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineTimeStamp"
-          readonly=""
-          type="text"
-          value="1.11.2019 09:41 - 1.11.2019 09:43"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="refNumber"
-      >
-        Asianumero
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="refNumber"
-          readonly=""
-          type="text"
-          value="Esim. 12345678"
-        />
-      </div>
-    </div>
-    <hr />
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="address"
-      >
-        Osoite
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="address"
-          readonly=""
-          type="text"
-          value="Näkinkuja 1c"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="additionalDetails"
-      >
-        Lisätietoja
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="additionalDetails"
-          readonly=""
-          type="text"
-          value="Kääntymispaikka"
-        />
-      </div>
-    </div>
-    <hr />
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineTitle-1"
-      >
-        Virhe
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <textarea
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineTitle-1"
-          readonly=""
-        >
-          Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
-        </textarea>
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineDetails-1"
-      >
-        Lisätieto
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineDetails-1"
-          readonly=""
-          type="text"
-          value="Liikennemerkistä n. 3 m"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineTitle-2"
-      >
-        Virhe
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <textarea
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineTitle-2"
-          readonly=""
-        >
-          Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
-        </textarea>
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineDetails-2"
-      >
-        Lisätieto
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineDetails-2"
-          readonly=""
-          type="text"
-          value="Liikennemerkistä n. 3 m"
-        />
-      </div>
-    </div>
-    <hr />
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="fineAdditionalDetails"
-      >
-        Pysäköintivirheen lisätiedot
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <textarea
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="fineAdditionalDetails"
-          readonly=""
-        >
-          Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen. 294 merkkiä
-        </textarea>
-      </div>
-    </div>
-    <hr />
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="sum"
-      >
-        Pysäköintivirhemaksun summa
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="sum"
-          readonly=""
-          type="text"
-          value="80,00 EUR"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="dueDate"
-      >
-        Eräpäivä
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="dueDate"
-          readonly=""
-          type="text"
-          value="2.12.2019"
-        />
-      </div>
-    </div>
-    <hr />
-    <div
-      class="barcode-container wide-field"
-    >
-      <div
-        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-      >
-        <label
-          class="FieldLabel-module_label__1zrXK "
-          for="barCode"
-        >
-          Virtuaaliviivakoodi
-        </label>
-        <div
-          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-        >
-          <input
-            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-            id="barCode"
-            readonly=""
-            type="text"
-            value="430123730001230560012400000000000000000100018714210302"
-          />
-        </div>
-      </div>
-      <button
-        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
-        data-testid="copy-to-clipboard"
-        type="button"
-      >
-        <div
-          aria-hidden="true"
-          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
-        >
-          <svg
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
+            Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+          </textarea>
         </div>
-        <span
-          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="fineDetails-1"
         >
-          Kopioi virtuaaliviivakoodi
-        </span>
-      </button>
+          Lisätieto
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="fineDetails-1"
+            readonly=""
+            type="text"
+            value="Liikennemerkistä n. 3 m"
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="fineTitle-2"
+        >
+          Virhe
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <textarea
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="fineTitle-2"
+            readonly=""
+          >
+            Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+          </textarea>
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="fineDetails-2"
+        >
+          Lisätieto
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="fineDetails-2"
+            readonly=""
+            type="text"
+            value="Liikennemerkistä n. 3 m"
+          />
+        </div>
+      </div>
+      <hr />
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="fineAdditionalDetails"
+        >
+          Pysäköintivirheen lisätiedot
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <textarea
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="fineAdditionalDetails"
+            readonly=""
+          >
+            Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen. 294 merkkiä
+          </textarea>
+        </div>
+      </div>
+      <hr />
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="sum"
+        >
+          Pysäköintivirhemaksun summa
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="sum"
+            readonly=""
+            type="text"
+            value="80,00 EUR"
+          />
+        </div>
+      </div>
+      <div
+        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+      >
+        <label
+          class="FieldLabel-module_label__1zrXK "
+          for="dueDate"
+        >
+          Eräpäivä
+        </label>
+        <div
+          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+        >
+          <input
+            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+            id="dueDate"
+            readonly=""
+            type="text"
+            value="2.12.2019"
+          />
+        </div>
+      </div>
+      <hr />
+      <div
+        class="barcode-container wide-field"
+      >
+        <div
+          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+        >
+          <label
+            class="FieldLabel-module_label__1zrXK "
+            for="barCode"
+          >
+            Virtuaaliviivakoodi
+          </label>
+          <div
+            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+          >
+            <input
+              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+              id="barCode"
+              readonly=""
+              type="text"
+              value="430123730001230560012400000000000000000100018714210302"
+            />
+          </div>
+        </div>
+        <button
+          class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
+          data-testid="copy-to-clipboard"
+          type="button"
+        >
+          <div
+            aria-hidden="true"
+            class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+          >
+            <svg
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
+          </div>
+          <span
+            class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+          >
+            Kopioi virtuaaliviivakoodi
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Component matches snapshot 1`] = `
   >
     <div
       class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
+      data-testid="carInfoCard"
       role="region"
     >
       <h2

--- a/src/components/reimbursement/ReimbursementSummary.css
+++ b/src/components/reimbursement/ReimbursementSummary.css
@@ -1,3 +1,12 @@
+.summary-body {
+  flex: 2 1;
+}
+
+.wide-field {
+  grid-column-start: 1;
+  grid-column-end: span 2;
+}
+
 .address-field {
   margin-bottom: var(--spacing-m);
 }

--- a/src/components/reimbursement/ReimbursementSummary.css
+++ b/src/components/reimbursement/ReimbursementSummary.css
@@ -1,0 +1,3 @@
+.address-field {
+  margin-bottom: var(--spacing-m);
+}

--- a/src/components/reimbursement/ReimbursementSummary.test.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import ReimbursementSummary from './ReimbursementSummary';
+import { Provider } from 'react-redux';
+import store from '../../store';
+import '@testing-library/jest-dom';
+import { t } from 'i18next';
+
+describe('reimbursement summary', () => {
+  test('passes a11y validation', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <ReimbursementSummary />
+      </Provider>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('renders correctly', async () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ReimbursementSummary />
+      </Provider>
+    );
+
+    // Car info card is visible
+    await waitFor(() => expect(getByTestId('carInfoCard')).toBeVisible());
+
+    // Summary fields are visible
+    const moveDate = screen.getByRole('textbox', {
+      name: t('moved-car:move-timestamp:label')
+    });
+    expect(moveDate).toBeInTheDocument();
+
+    const refNumberEl = screen.getByRole('textbox', {
+      name: t('common:fine-info:ref-number:label')
+    });
+    expect(refNumberEl).toBeInTheDocument();
+
+    const moveReasonEl = screen.getByRole('textbox', {
+      name: t('moved-car:move-reason:label')
+    });
+    expect(moveReasonEl).toBeInTheDocument();
+
+    const moveTypeEl = screen.getByRole('textbox', {
+      name: t('moved-car:move-type:label')
+    });
+    expect(moveTypeEl).toBeInTheDocument();
+
+    const moveAddressFromEl = screen.getByRole('textbox', {
+      name: t('moved-car:address-from:label')
+    });
+    expect(moveAddressFromEl).toBeInTheDocument();
+
+    const moveAddressToEl = screen.getByRole('textbox', {
+      name: t('moved-car:address-to:label')
+    });
+    expect(moveAddressToEl).toBeInTheDocument();
+
+    const reimbursementSum = screen.getByRole('textbox', {
+      name: t('moved-car:reimbursement-sum:label')
+    });
+    expect(reimbursementSum).toBeInTheDocument();
+
+    const barcodeEl = screen.getByRole('textbox', {
+      name: t('common:barcode:label')
+    });
+    expect(barcodeEl).toBeInTheDocument();
+  });
+});

--- a/src/components/reimbursement/ReimbursementSummary.test.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import ReimbursementSummary from './ReimbursementSummary';
 import { Provider } from 'react-redux';
@@ -18,14 +18,11 @@ describe('reimbursement summary', () => {
   });
 
   test('renders correctly', async () => {
-    const { getByTestId } = render(
+    render(
       <Provider store={store}>
         <ReimbursementSummary />
       </Provider>
     );
-
-    // Car info card is visible
-    await waitFor(() => expect(getByTestId('carInfoCard')).toBeVisible());
 
     // Summary fields are visible
     const moveDate = screen.getByRole('textbox', {

--- a/src/components/reimbursement/ReimbursementSummary.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.tsx
@@ -10,7 +10,7 @@ const ReimbursementSummary = (): React.ReactElement => {
 
   return (
     <div>
-      <div className="summary-container">
+      <div data-testid="reimbursementSummary" className="summary-container">
         <CarInfoCard />
         <TextInput
           id="moveTimeStamp"

--- a/src/components/reimbursement/ReimbursementSummary.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { TextArea, TextInput } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import Barcode from '../barcode/Barcode';
+import CarInfoCard from '../carInfoCard/CarInfoCard';
+
+const ReimbursementSummary = (): React.ReactElement => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <div className="summary-container">
+        <CarInfoCard />
+        <TextInput
+          className="info-field"
+          id="moveTimeStamp"
+          label={t('moved-car:move-timestamp:label')}
+          value={t('moved-car:move-timestamp:placeholder')}
+          readOnly
+        />
+        <TextInput
+          className="info-field"
+          id="refNumber"
+          label={t('common:fine-info:ref-number:label')}
+          value={t('common:fine-info:ref-number:placeholder')}
+          readOnly
+        />
+        <hr />
+        <TextInput
+          className="info-field"
+          id="moveReason"
+          label={t('moved-car:move-reason:label')}
+          value={t('moved-car:move-reason:placeholder')}
+          readOnly
+        />
+        <div />
+        <TextInput
+          className="info-field"
+          id="moveType"
+          label={t('moved-car:move-type:label')}
+          value={t('moved-car:move-type:placeholder')}
+          readOnly
+        />
+        <div />
+        <hr />
+        <TextArea
+          className="info-field"
+          id="addressFrom"
+          label={t('moved-car:address-from:label')}
+          value={t('moved-car:address-from:placeholder')}
+          readOnly
+        />
+        <TextInput
+          className="info-field"
+          id="addressFromDetails"
+          label={t('moved-car:address-from:details-label')}
+          value={t('moved-car:address-from:details-placeholder')}
+          readOnly
+        />
+        <TextArea
+          className="info-field"
+          id="addressTo"
+          label={t('moved-car:address-to:label')}
+          value={t('moved-car:address-to:placeholder')}
+          readOnly
+        />
+        <TextInput
+          className="info-field"
+          id="addressToDetails"
+          label={t('moved-car:address-to:details-label')}
+          value={t('moved-car:address-to:details-placeholder')}
+          readOnly
+        />
+        <hr />
+        <TextInput
+          id="reimbursementSum"
+          label={t('moved-car:reimbursement-sum:label')}
+          value={t('moved-car:reimbursement-sum:placeholder')}
+          readOnly
+          className="info-field sum-field"
+        />
+        <TextInput
+          className="info-field"
+          id="reimbursementDueDate"
+          label={t('common:fine-info:due-date:label')}
+          value={t('common:fine-info:due-date:placeholder')}
+          readOnly
+        />
+        <hr />
+        <Barcode
+          barcode="430123730001230560012400000000000000000100018714210302"
+          className="wide-field"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ReimbursementSummary;

--- a/src/components/reimbursement/ReimbursementSummary.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { TextArea, TextInput } from 'hds-react';
+import { TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import Barcode from '../barcode/Barcode';
 import CarInfoCard from '../carInfoCard/CarInfoCard';
+import './ReimbursementSummary.css';
 
 const ReimbursementSummary = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -12,14 +13,12 @@ const ReimbursementSummary = (): React.ReactElement => {
       <div className="summary-container">
         <CarInfoCard />
         <TextInput
-          className="info-field"
           id="moveTimeStamp"
           label={t('moved-car:move-timestamp:label')}
           value={t('moved-car:move-timestamp:placeholder')}
           readOnly
         />
         <TextInput
-          className="info-field"
           id="refNumber"
           label={t('common:fine-info:ref-number:label')}
           value={t('common:fine-info:ref-number:placeholder')}
@@ -27,15 +26,14 @@ const ReimbursementSummary = (): React.ReactElement => {
         />
         <hr />
         <TextInput
-          className="info-field"
           id="moveReason"
           label={t('moved-car:move-reason:label')}
           value={t('moved-car:move-reason:placeholder')}
           readOnly
         />
         <div />
+        <hr />
         <TextInput
-          className="info-field"
           id="moveType"
           label={t('moved-car:move-type:label')}
           value={t('moved-car:move-type:placeholder')}
@@ -43,8 +41,8 @@ const ReimbursementSummary = (): React.ReactElement => {
         />
         <div />
         <hr />
-        <TextArea
-          className="info-field"
+        <TextInput
+          className="address-field"
           id="addressFrom"
           label={t('moved-car:address-from:label')}
           value={t('moved-car:address-from:placeholder')}
@@ -57,15 +55,13 @@ const ReimbursementSummary = (): React.ReactElement => {
           value={t('moved-car:address-from:details-placeholder')}
           readOnly
         />
-        <TextArea
-          className="info-field"
+        <TextInput
           id="addressTo"
           label={t('moved-car:address-to:label')}
           value={t('moved-car:address-to:placeholder')}
           readOnly
         />
         <TextInput
-          className="info-field"
           id="addressToDetails"
           label={t('moved-car:address-to:details-label')}
           value={t('moved-car:address-to:details-placeholder')}
@@ -77,10 +73,8 @@ const ReimbursementSummary = (): React.ReactElement => {
           label={t('moved-car:reimbursement-sum:label')}
           value={t('moved-car:reimbursement-sum:placeholder')}
           readOnly
-          className="info-field sum-field"
         />
         <TextInput
-          className="info-field"
           id="reimbursementDueDate"
           label={t('common:fine-info:due-date:label')}
           value={t('common:fine-info:due-date:placeholder')}

--- a/src/components/reimbursement/ReimbursementSummary.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import Barcode from '../barcode/Barcode';
-import CarInfoCard from '../carInfoCard/CarInfoCard';
 import './ReimbursementSummary.css';
 
 const ReimbursementSummary = (): React.ReactElement => {
   const { t } = useTranslation();
 
   return (
-    <div>
+    <div className="summary-body">
       <div data-testid="reimbursementSummary" className="summary-container">
-        <CarInfoCard />
         <TextInput
           id="moveTimeStamp"
           label={t('moved-car:move-timestamp:label')}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -156,7 +156,35 @@
       "step3": "Oikaisuvaatimus",
       "step4": "Yhteenveto"
     },
-    "submit": "Lähetä"
+    "submit": "Lähetä",
+    "move-timestamp": {
+      "label": "Siirron päivämäärä",
+      "placeholder": "1.11.2019"
+    },
+    "move-reason": {
+      "label": "Siirron syy",
+      "placeholder": "Katualue varattu"
+    },
+    "move-type": {
+      "label": "Siirron tyyppi",
+      "placeholder": "Maksullinen lähisiirto"
+    },
+    "address-from": {
+      "label": "Siirron lähtöosoite",
+      "placeholder": "Urheilukatu 38",
+      "details-label": "Lähtöosoitteen lisätiedot",
+      "details-placeholder": "Näytetään, jos on lisätietoja"
+    },
+    "address-to": {
+      "label": "Siirron pääteosoite",
+      "placeholder": "Urheilukatu 40",
+      "details-label": "Päätesoitteen lisätiedot",
+      "details-placeholder": "Näytetään, jos on lisätietoja"
+    },
+    "reimbursement-sum": {
+      "label": "Korvauspäätöksen summa",
+      "placeholder": "85,00 EUR"
+    }
   },
   "rectification": {
     "relation-info": {


### PR DESCRIPTION
This PR:
* Adds reimbursement summary as the second view of moved car appeal form
* Creates a new component InfoContainer that contains common stuff from ParkingFineSummary and ReimbursementSummary
* Moves car info card to its own component

![Screenshot 2022-12-07 at 16 34 14](https://user-images.githubusercontent.com/36920208/206206775-a904c8d4-e2be-4a4c-a12f-97d4c4b5f002.png)
