### PR TITLE
Fix summary view on moved car appeal form

### DIFF
--- a/src/components/barcode/Barcode.tsx
+++ b/src/components/barcode/Barcode.tsx
@@ -22,7 +22,7 @@ const Barcode = (props: BarcodeProps) => {
   return (
     <>
       <div className={`barcode-container ${className ? className : ''}`}>
-        <p className="barcode-label">{t('common:barcode:label')}</p>
+        <label className="barcode-label">{t('common:barcode:label')}</label>
         <p className="barcode">{barcode}</p>
         <Button
           data-testid="copy-to-clipboard"

--- a/src/components/barcode/__snapshots__/Barcode.test.tsx.snap
+++ b/src/components/barcode/__snapshots__/Barcode.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`Component matches snapshot 1`] = `
   <div
     class="barcode-container "
   >
-    <p
+    <label
       class="barcode-label"
     >
       Virtuaaliviivakoodi
-    </p>
+    </label>
     <p
       class="barcode"
     >

--- a/src/components/formContent/FormContent.css
+++ b/src/components/formContent/FormContent.css
@@ -2,6 +2,10 @@
   padding: 4px 0 12px;
 }
 
+.form-body {
+  margin-top: var(--spacing-xl);
+}
+
 @media (max-width: 767px) {
   .button.print {
     margin-bottom: var(--spacing-xs);

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -31,9 +31,17 @@ const FormContent = (props: Props): React.ReactElement => {
       {
         {
           0: <SearchForm />,
-          1: selectForm(formContent.selectedForm),
+          1: (
+            <div className="form-body">
+              {selectForm(formContent.selectedForm)}
+            </div>
+          ),
           2: <RectificationForm />,
-          3: <RectificationSummary />
+          3: (
+            <div className="form-body">
+              <RectificationSummary />
+            </div>
+          )
         }[props.activeStep]
       }
     </div>

--- a/src/components/infoContainer/InfoContainer.css
+++ b/src/components/infoContainer/InfoContainer.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-m);
-  margin-top: var(--spacing-xl);
 }
 
 .summary-container {

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Component matches snapshot 1`] = `
           class="FieldLabel-module_label__1zrXK "
           for="address"
         >
-          Osoite
+          Lähiosoite
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
@@ -248,11 +248,11 @@ exports[`Component matches snapshot 1`] = `
       <div
         class="barcode-container wide-field"
       >
-        <p
+        <label
           class="barcode-label"
         >
           Virtuaaliviivakoodi
-        </p>
+        </label>
         <p
           class="barcode"
         >

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Component in moved car form matches snapshot 1`] = `
           <legend
             class="SelectionGroup-module_label__qlluz"
           >
-            Teen oikaisuvaatimuksen *
+            Teen oikaisuvaatimuksen
              
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
@@ -536,7 +536,7 @@ exports[`Component in moved car form matches snapshot 1`] = `
           class="FieldLabel-module_label__1zrXK "
           for="address"
         >
-          Osoite
+          Lähiosoite
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
@@ -1370,7 +1370,7 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
           class="FieldLabel-module_label__1zrXK "
           for="address"
         >
-          Osoite
+          Lähiosoite
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >

--- a/src/components/rectificationSummary/RectificationSummary.css
+++ b/src/components/rectificationSummary/RectificationSummary.css
@@ -13,13 +13,14 @@
 }
 
 .rectification-summary-header {
-  margin-top: 52px;
+  margin-top: var(--spacing-xl);
   font-weight: 500;
   line-height: 32px;
   letter-spacing: -0.2px;
 }
 
 .rectification-summary-fine-details {
+  margin-top: var(--spacing-m);
   grid-column: 1 / 3;
 }
 

--- a/src/components/rectificationSummary/RectificationSummary.test.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.test.tsx
@@ -4,9 +4,25 @@ import { axe } from 'jest-axe';
 import RectificationSummary from './RectificationSummary';
 import store from '../../store';
 import { Provider } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
 
 describe('Component', () => {
   it('matches snapshot', () => {
+    const formContentSliceMock = createSlice({
+      name: 'formContent',
+      initialState: {
+        formSubmitted: false,
+        selectedForm: 'parking-fine',
+        submitDisabled: true
+      },
+      reducers: {}
+    });
+
+    const store = configureStore({
+      reducer: {
+        formContent: formContentSliceMock.reducer
+      }
+    });
     const { container } = render(
       <Provider store={store}>
         <RectificationSummary />

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Accordion, TextArea, TextInput } from 'hds-react';
 
 import './RectificationSummary.css';
 import { useTranslation } from 'react-i18next';
 import InfoContainer from '../infoContainer/InfoContainer';
+import { selectFormContent } from '../formContent/formContentSlice';
 
 const RectificationSummary = () => {
   const { t } = useTranslation();
+  const selectedForm = useSelector(selectFormContent).selectedForm;
 
   return (
     <>
@@ -17,8 +20,8 @@ const RectificationSummary = () => {
         <div className="rectification-summary-details">
           <TextInput
             id="relation"
-            label={t('rectification:relation-info:parking-fine:relation')}
-            value={t('rectification:relation-info:parking-fine:driver')}
+            label={t(`rectification:relation-info:${selectedForm}:relation`)}
+            value={t(`rectification:relation-info:${selectedForm}:driver`)}
             readOnly
           />
           <TextInput
@@ -88,8 +91,8 @@ const RectificationSummary = () => {
         </div>
 
         <Accordion
-          id="fineSummary"
-          heading={t('parking-fine:fine-info')}
+          id="summary"
+          heading={t(`${selectedForm}:stepper:step2`)}
           className="rectification-summary-fine-details">
           <InfoContainer />
         </Accordion>

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Component matches snapshot 1`] = `
           class="FieldLabel-module_label__1zrXK "
           for="rectification-address"
         >
-          Osoite
+          Lähiosoite
         </label>
         <div
           class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
@@ -255,19 +255,19 @@ exports[`Component matches snapshot 1`] = `
     </div>
     <div
       class="Accordion-module_accordion__2fPUT Accordion-module_m__2k6QY rectification-summary-fine-details"
-      id="fineSummary"
+      id="summary"
     >
       <div
         class="Accordion-module_accordionHeader__3_uK7"
       >
         <div
           aria-level="2"
-          id="fineSummary-heading"
+          id="summary-heading"
           role="heading"
         >
           <div
             aria-expanded="false"
-            aria-labelledby="fineSummary-heading"
+            aria-labelledby="summary-heading"
             class="Accordion-module_headingContainer__1DzX3"
             role="button"
             tabindex="0"
@@ -301,15 +301,310 @@ exports[`Component matches snapshot 1`] = `
         </div>
       </div>
       <div
-        aria-labelledby="fineSummary-heading"
+        aria-labelledby="summary-heading"
         class="Accordion-module_accordionContent__1umso Accordion-module_contentWithCloseButton__-einM"
-        id="fineSummary-content"
+        id="summary-content"
         role="region"
         style="display: none;"
       >
         <div
           class="info-container"
         >
+          <div
+            class="summary-body"
+          >
+            <div
+              class="summary-container"
+              data-testid="parkingFineSummary"
+            >
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineTimeStamp"
+                >
+                  Virheen ajankohta
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineTimeStamp"
+                    readonly=""
+                    type="text"
+                    value="1.11.2019 09:41 - 1.11.2019 09:43"
+                  />
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="refNumber"
+                >
+                  Asianumero
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="refNumber"
+                    readonly=""
+                    type="text"
+                    value="Esim. 12345678"
+                  />
+                </div>
+              </div>
+              <hr />
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="address"
+                >
+                  Lähiosoite
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="address"
+                    readonly=""
+                    type="text"
+                    value="Näkinkuja 1c"
+                  />
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="additionalDetails"
+                >
+                  Lisätietoja
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="additionalDetails"
+                    readonly=""
+                    type="text"
+                    value="Kääntymispaikka"
+                  />
+                </div>
+              </div>
+              <hr />
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineTitle-1"
+                >
+                  Virhe
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <textarea
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineTitle-1"
+                    readonly=""
+                  >
+                    Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+                  </textarea>
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineDetails-1"
+                >
+                  Lisätieto
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineDetails-1"
+                    readonly=""
+                    type="text"
+                    value="Liikennemerkistä n. 3 m"
+                  />
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineTitle-2"
+                >
+                  Virhe
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <textarea
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineTitle-2"
+                    readonly=""
+                  >
+                    Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+                  </textarea>
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineDetails-2"
+                >
+                  Lisätieto
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineDetails-2"
+                    readonly=""
+                    type="text"
+                    value="Liikennemerkistä n. 3 m"
+                  />
+                </div>
+              </div>
+              <hr />
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="fineAdditionalDetails"
+                >
+                  Pysäköintivirheen lisätiedot
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <textarea
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="fineAdditionalDetails"
+                    readonly=""
+                  >
+                    Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen. 294 merkkiä
+                  </textarea>
+                </div>
+              </div>
+              <hr />
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="sum"
+                >
+                  Pysäköintivirhemaksun summa
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="sum"
+                    readonly=""
+                    type="text"
+                    value="80,00 EUR"
+                  />
+                </div>
+              </div>
+              <div
+                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="dueDate"
+                >
+                  Eräpäivä
+                </label>
+                <div
+                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                >
+                  <input
+                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                    id="dueDate"
+                    readonly=""
+                    type="text"
+                    value="2.12.2019"
+                  />
+                </div>
+              </div>
+              <hr />
+              <div
+                class="barcode-container wide-field"
+              >
+                <label
+                  class="barcode-label"
+                >
+                  Virtuaaliviivakoodi
+                </label>
+                <p
+                  class="barcode"
+                >
+                  430123730001230560012400000000000000000100018714210302
+                </p>
+                <button
+                  class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
+                  data-testid="copy-to-clipboard"
+                  type="button"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <rect
+                          height="24"
+                          width="24"
+                        />
+                        <path
+                          d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                  <span
+                    class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                  >
+                    Kopioi virtuaaliviivakoodi
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
           <div
             class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
             data-testid="carInfoCard"
@@ -461,7 +756,7 @@ exports[`Component matches snapshot 1`] = `
         <button
           aria-label="Sulje Pysäköintivirhemaksun tiedot"
           class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
-          data-testid="fineSummary-closeButton"
+          data-testid="summary-closeButton"
           type="button"
         >
           <span

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -54,7 +54,7 @@
         "placeholder": "1.11.2019 09:41 - 1.11.2019 09:43"
       },
       "address": {
-        "label": "Osoite",
+        "label": "Lähiosoite",
         "placeholder": "Näkinkuja 1c"
       },
       "fine-title": {
@@ -88,7 +88,7 @@
     "fine-info": "Pysäköintivirhemaksun tiedot",
     "stepper": {
       "step1": "Haku",
-      "step2": "Pysäköintivirhemaksu",
+      "step2": "Pysäköintivirhemaksun tiedot",
       "step3": "Oikaisuvaatimus",
       "step4": "Yhteenveto"
     },
@@ -197,7 +197,7 @@
         "holder": "Haltija"
       },
       "moved-car": {
-        "relation": "Teen oikaisuvaatimuksen *",
+        "relation": "Teen oikaisuvaatimuksen",
         "driver": "Ajoneuvon kuljettajana",
         "owner": "Ajoneuvon omistajana",
         "poa-holder": "Valtakirjalla"
@@ -207,7 +207,7 @@
     "rectification-content": "Oikaisuvaatimuksen sisältö",
     "description-over-limit": "Kuvaus ylittää merkkimäärän",
     "to-separate-email": "Haluan ilmoitukset asian käsittelystä eri sähköpostiosoitteeseen",
-    "address": "Osoite",
+    "address": "Lähiosoite",
     "zipcode": "Postinumero",
     "city": "Postitoimipaikka",
     "area-code": "Maakoodi",


### PR DESCRIPTION
This PR fixes the last step (= summary) view of moved car appeal form to comply with the design. Also some small text changes.

TODO:
- Show attached files' names on the summary page