### PR TITLE
Show attachments on summary view

### DIFF
--- a/src/components/rectification/RectificationForm.css
+++ b/src/components/rectification/RectificationForm.css
@@ -22,7 +22,8 @@
   grid-row: 1 / 7;
 }
 
-.rectification-textarea div:first-of-type, .rectification-textarea textarea {
+.rectification-textarea div:first-of-type,
+.rectification-textarea textarea {
   height: 100% !important;
 }
 

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -18,14 +18,14 @@ import {
 } from 'hds-react';
 import { useClient } from '../../client/hooks';
 import { FormId, selectFormContent } from '../formContent/formContentSlice';
-
+import { FileItem, setPOAFile, setAttachments } from './rectificationFormSlice';
 import './RectificationForm.css';
 
 type Language = 'fi' | 'en' | 'sv';
 
 const RectificationForm = () => {
   const { t, i18n } = useTranslation();
-
+  const dispatch = useDispatch();
   const { getUser } = useClient();
   const user = getUser();
   const selectedForm = useSelector(selectFormContent).selectedForm;
@@ -56,6 +56,24 @@ const RectificationForm = () => {
 
   const handleDraftSave = () => {
     setShowDraftSavedNotification(true);
+  };
+
+  const setFiles = (files: File[], type: string) => {
+    const fileList: FileItem[] = [];
+    for (const file of files) {
+      const fileItem = {
+        name: file.name,
+        size: file.size,
+        type: file.type
+      };
+      fileList.push(fileItem);
+    }
+    switch (type) {
+      case 'poa':
+        return dispatch(setPOAFile(fileList[0]));
+      case 'attachments':
+        return dispatch(setAttachments(fileList));
+    }
   };
 
   const relations = movedCarFormSelected
@@ -127,7 +145,7 @@ const RectificationForm = () => {
                 language={i18n.language as Language}
                 label={t('rectification:attach-poa')}
                 id="rectificationPOAFile"
-                onChange={() => null}
+                onChange={e => setFiles(e, 'poa')}
                 dragAndDrop
                 accept={'.png, .jpg, .pdf'}
               />
@@ -234,7 +252,7 @@ const RectificationForm = () => {
             className="rectification-fileinput"
             label={t('rectification:attachments')}
             id="rectificationAttachments"
-            onChange={() => null}
+            onChange={e => setFiles(e, 'attachments')}
             dragAndDrop
             accept={'.png, .jpg, .pdf'}
           />

--- a/src/components/rectification/rectificationFormSlice.tsx
+++ b/src/components/rectification/rectificationFormSlice.tsx
@@ -1,0 +1,44 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+export type FileItem = {
+  name: string;
+  size: number;
+  type: string;
+};
+
+type SliceState = {
+  poaFile: FileItem;
+  attachments: FileItem[];
+};
+
+const initialState: SliceState = {
+  poaFile: {
+    name: '',
+    size: 0,
+    type: ''
+  },
+  attachments: []
+};
+
+export const slice = createSlice({
+  name: 'rectificationForm',
+  initialState,
+  reducers: {
+    setPOAFile: (state, action) => {
+      state.poaFile = action.payload;
+    },
+    setAttachments: (state, action) => {
+      state.attachments = action.payload;
+    }
+  }
+});
+
+// Actions
+export const { setPOAFile, setAttachments } = slice.actions;
+
+// Selectors
+export const selectRectificationFormValues = (state: RootState) =>
+  state.rectificationForm;
+
+export default slice.reducer;

--- a/src/components/rectificationSummary/RectificationSummary.css
+++ b/src/components/rectificationSummary/RectificationSummary.css
@@ -1,6 +1,7 @@
 .rectification-summary-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-m);
 }
 
 .rectification-summary-subgrid {
@@ -11,7 +12,7 @@
 .rectification-summary-content,
 .rectification-summary-content div,
 .rectification-summary-content textarea {
-  height: 90vh !important;
+  height: 99% !important;
 }
 
 .rectification-summary-header {

--- a/src/components/rectificationSummary/RectificationSummary.css
+++ b/src/components/rectificationSummary/RectificationSummary.css
@@ -8,8 +8,10 @@
   grid-template-columns: 1fr 1fr;
 }
 
-.rectification-summary-content, .rectification-summary-content div, .rectification-summary-content textarea {
-  height: 100% !important;
+.rectification-summary-content,
+.rectification-summary-content div,
+.rectification-summary-content textarea {
+  height: 90vh !important;
 }
 
 .rectification-summary-header {
@@ -25,5 +27,42 @@
 }
 
 .rectification-summary-details > div {
-  margin-bottom: 24px;
+  margin-bottom: var(--spacing-m);
+}
+
+.file-list {
+  list-style: none;
+  margin: var(--spacing-s) 0 0;
+  padding: 0;
+}
+
+.file-list-item {
+  align-items: flex-start;
+  background-color: var(--color-info-light);
+  border-bottom: 2px dotted var(--color-coat-of-arms);
+  box-sizing: border-box;
+  display: flex;
+  padding: var(--spacing-s) var(--spacing-2-xs);
+  margin-top: var(--spacing-s);
+  max-width: 500px;
+}
+
+.file-list-item-title {
+  align-items: flex-start;
+  display: flex;
+  flex: 1;
+  flex-wrap: nowrap;
+  font-size: var(--fontsize-body-s);
+  margin: 2px var(--spacing-xs) 0 var(--spacing-2-xs);
+}
+
+.file-list-item-name {
+  hyphens: auto;
+  word-break: break-word;
+}
+
+.file-list-item-size {
+  margin-left: var(--spacing-2-xs);
+  text-align: right;
+  white-space: nowrap;
 }

--- a/src/components/rectificationSummary/RectificationSummary.test.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.test.tsx
@@ -18,9 +18,23 @@ describe('Component', () => {
       reducers: {}
     });
 
+    const rectificationFormSliceMock = createSlice({
+      name: 'rectificationForm',
+      initialState: {
+        poaFile: {
+          name: '',
+          size: 0,
+          type: ''
+        },
+        attachments: []
+      },
+      reducers: {}
+    });
+
     const store = configureStore({
       reducer: {
-        formContent: formContentSliceMock.reducer
+        formContent: formContentSliceMock.reducer,
+        rectificationForm: rectificationFormSliceMock.reducer
       }
     });
     const { container } = render(

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -93,8 +93,6 @@ const RectificationSummary = () => {
             value="Pysäköinnin asiointikansiooni"
             readOnly
           />
-        </div>
-        <div>
           {attachments.length > 0 && (
             <div>
               <label className={styles['text-label']}>
@@ -119,8 +117,6 @@ const RectificationSummary = () => {
               </ul>
             </div>
           )}
-        </div>
-        <div>
           {selectedForm === FormId.MOVEDCAR && poaFile.name && (
             <div>
               <label className={styles['text-label']}>

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Accordion, TextArea, TextInput } from 'hds-react';
-
-import './RectificationSummary.css';
+import {
+  Accordion,
+  IconDocument,
+  IconPhoto,
+  TextArea,
+  TextInput
+} from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { formatBytes } from '../../utils/helpers';
 import InfoContainer from '../infoContainer/InfoContainer';
-import { selectFormContent } from '../formContent/formContentSlice';
+import { FormId, selectFormContent } from '../formContent/formContentSlice';
+import {
+  FileItem,
+  selectRectificationFormValues
+} from '../rectification/rectificationFormSlice';
+import styles from '../styles.module.css';
+import './RectificationSummary.css';
 
 const RectificationSummary = () => {
   const { t } = useTranslation();
   const selectedForm = useSelector(selectFormContent).selectedForm;
+  const poaFile = useSelector(selectRectificationFormValues).poaFile;
+  const attachments = useSelector(selectRectificationFormValues).attachments;
 
   return (
     <>
@@ -81,6 +94,54 @@ const RectificationSummary = () => {
             readOnly
           />
         </div>
+        <div>
+          {attachments.length > 0 && (
+            <div>
+              <label className={styles['text-label']}>
+                {t('rectification:attachments')}
+              </label>
+              <ul className="file-list">
+                {attachments.map((item: FileItem) => (
+                  <li key={item.name} className="file-list-item">
+                    {item.type.startsWith('image') ? (
+                      <IconPhoto aria-hidden />
+                    ) : (
+                      <IconDocument aria-hidden />
+                    )}
+                    <div className="file-list-item-title">
+                      <span className="file-list-item-name">{item.name}</span>
+                      <span className="file-list-item-size">
+                        ({formatBytes(item.size)})
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div>
+          {selectedForm === FormId.MOVEDCAR && poaFile.name && (
+            <div>
+              <label className={styles['text-label']}>
+                {t('rectification:poa')}
+              </label>
+              <div className="file-list-item">
+                {poaFile.type.startsWith('image') ? (
+                  <IconPhoto aria-hidden />
+                ) : (
+                  <IconDocument aria-hidden />
+                )}
+                <div className="file-list-item-title">
+                  <span className="file-list-item-name">{poaFile.name}</span>
+                  <span className="file-list-item-size">
+                    ({formatBytes(poaFile.size)})
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="rectification-summary-content">
           <TextArea
             readOnly
@@ -89,14 +150,13 @@ const RectificationSummary = () => {
             value="Mieleni minun tekevi, aivoni ajattelevi lähteäni laulamahan, saa'ani sanelemahan, sukuvirttä suoltamahan, lajivirttä laulamahan. Sanat suussani sulavat, puhe'et putoelevat, kielelleni kerkiävät, hampahilleni hajoovat.Veli kulta, veikkoseni, kaunis kasvinkumppalini! Lähe nyt kanssa laulamahan, saa kera sanelemahan yhtehen yhyttyämme, kahta'alta käytyämme! Harvoin yhtehen yhymme, saamme toinen toisihimme näillä raukoilla rajoilla, poloisilla Pohjan mailla.Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen, Joukahaisen jousen tiestä, Pohjan peltojen periltä, Kalevalan kankahilta.Niit' ennen isoni lauloi kirvesvartta vuollessansa; niitä äitini opetti väätessänsä värttinätä, minun lasna lattialla eessä polven pyöriessä, maitopartana pahaisna, piimäsuuna pikkaraisna. Sampo ei puuttunut sanoja eikä Louhi luottehia: vanheni sanoihin sampo, katoi Louhi luottehisin, virsihin Vipunen kuoli, Lemminkäinen leikkilöihin.Viel' on muitaki sanoja, ongelmoita oppimia: tieohesta tempomia, kanervoista katkomia, risukoista riipomia, vesoista vetelemiä, päästä heinän hieromia, raitiolta ratkomia, paimenessa käyessäni, lasna karjanlaitumilla, metisillä mättähillä, kultaisilla kunnahilla, mustan Muurikin jälessä, Kimmon kirjavan keralla.Vilu mulle virttä virkkoi, sae saatteli runoja. Virttä toista tuulet toivat, meren aaltoset ajoivat. Linnut liitteli sanoja, puien latvat lausehia. Mieleni minun tekevi, aivoni ajattelevi lähteäni laulamahan, saa'ani sanelemahan, sukuvirttä suoltamahan, lajivirttä laulamahan. Sanat suussani sulavat, puhe'et putoelevat, kielelleni kerkiävät, hampahilleni hajoovat.Veli kulta, veikkoseni, kaunis kasvinkumppalini! Lähe nyt kanssa laulamahan, saa kera sanelemahan yhtehen yhyttyämme, kahta'alta käytyämme! Harvoin yhtehen yhymme, saamme toinen toisihimme näillä raukoilla rajoilla, poloisilla Pohjan mailla.Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen 2374 merkkiä"
           />
         </div>
-
-        <Accordion
-          id="summary"
-          heading={t(`${selectedForm}:stepper:step2`)}
-          className="rectification-summary-fine-details">
-          <InfoContainer />
-        </Accordion>
       </div>
+      <Accordion
+        id="fineSummary"
+        heading={t('parking-fine:fine-info')}
+        className="rectification-summary-fine-details">
+        <InfoContainer />
+      </Accordion>
     </>
   );
 };

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -228,8 +228,6 @@ exports[`Component matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div />
-    <div />
     <div
       class="rectification-summary-content"
     >

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -228,6 +228,8 @@ exports[`Component matches snapshot 1`] = `
         </div>
       </div>
     </div>
+    <div />
+    <div />
     <div
       class="rectification-summary-content"
     >
@@ -253,544 +255,544 @@ exports[`Component matches snapshot 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="Accordion-module_accordion__2fPUT Accordion-module_m__2k6QY rectification-summary-fine-details"
+    id="fineSummary"
+  >
     <div
-      class="Accordion-module_accordion__2fPUT Accordion-module_m__2k6QY rectification-summary-fine-details"
-      id="summary"
+      class="Accordion-module_accordionHeader__3_uK7"
     >
       <div
-        class="Accordion-module_accordionHeader__3_uK7"
+        aria-level="2"
+        id="fineSummary-heading"
+        role="heading"
       >
         <div
-          aria-level="2"
-          id="summary-heading"
-          role="heading"
-        >
-          <div
-            aria-expanded="false"
-            aria-labelledby="summary-heading"
-            class="Accordion-module_headingContainer__1DzX3"
-            role="button"
-            tabindex="0"
-          >
-            <span
-              class="label"
-            >
-              Pysäköintivirhemaksun tiedot
-            </span>
-            <svg
-              aria-hidden="true"
-              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                />
-                <path
-                  d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-                  fill="currentColor"
-                />
-              </g>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-labelledby="summary-heading"
-        class="Accordion-module_accordionContent__1umso Accordion-module_contentWithCloseButton__-einM"
-        id="summary-content"
-        role="region"
-        style="display: none;"
-      >
-        <div
-          class="info-container"
-        >
-          <div
-            class="summary-body"
-          >
-            <div
-              class="summary-container"
-              data-testid="parkingFineSummary"
-            >
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineTimeStamp"
-                >
-                  Virheen ajankohta
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineTimeStamp"
-                    readonly=""
-                    type="text"
-                    value="1.11.2019 09:41 - 1.11.2019 09:43"
-                  />
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="refNumber"
-                >
-                  Asianumero
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="refNumber"
-                    readonly=""
-                    type="text"
-                    value="Esim. 12345678"
-                  />
-                </div>
-              </div>
-              <hr />
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="address"
-                >
-                  Lähiosoite
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="address"
-                    readonly=""
-                    type="text"
-                    value="Näkinkuja 1c"
-                  />
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="additionalDetails"
-                >
-                  Lisätietoja
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="additionalDetails"
-                    readonly=""
-                    type="text"
-                    value="Kääntymispaikka"
-                  />
-                </div>
-              </div>
-              <hr />
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineTitle-1"
-                >
-                  Virhe
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <textarea
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineTitle-1"
-                    readonly=""
-                  >
-                    Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
-                  </textarea>
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineDetails-1"
-                >
-                  Lisätieto
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineDetails-1"
-                    readonly=""
-                    type="text"
-                    value="Liikennemerkistä n. 3 m"
-                  />
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineTitle-2"
-                >
-                  Virhe
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <textarea
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineTitle-2"
-                    readonly=""
-                  >
-                    Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
-                  </textarea>
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineDetails-2"
-                >
-                  Lisätieto
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineDetails-2"
-                    readonly=""
-                    type="text"
-                    value="Liikennemerkistä n. 3 m"
-                  />
-                </div>
-              </div>
-              <hr />
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="fineAdditionalDetails"
-                >
-                  Pysäköintivirheen lisätiedot
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <textarea
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="fineAdditionalDetails"
-                    readonly=""
-                  >
-                    Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen. 294 merkkiä
-                  </textarea>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="sum"
-                >
-                  Pysäköintivirhemaksun summa
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="sum"
-                    readonly=""
-                    type="text"
-                    value="80,00 EUR"
-                  />
-                </div>
-              </div>
-              <div
-                class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
-              >
-                <label
-                  class="FieldLabel-module_label__1zrXK "
-                  for="dueDate"
-                >
-                  Eräpäivä
-                </label>
-                <div
-                  class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-                >
-                  <input
-                    class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                    id="dueDate"
-                    readonly=""
-                    type="text"
-                    value="2.12.2019"
-                  />
-                </div>
-              </div>
-              <hr />
-              <div
-                class="barcode-container wide-field"
-              >
-                <label
-                  class="barcode-label"
-                >
-                  Virtuaaliviivakoodi
-                </label>
-                <p
-                  class="barcode"
-                >
-                  430123730001230560012400000000000000000100018714210302
-                </p>
-                <button
-                  class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
-                  data-testid="copy-to-clipboard"
-                  type="button"
-                >
-                  <div
-                    aria-hidden="true"
-                    class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
-                  >
-                    <svg
-                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g
-                        fill="none"
-                        fill-rule="evenodd"
-                      >
-                        <rect
-                          height="24"
-                          width="24"
-                        />
-                        <path
-                          d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
-                          fill="currentColor"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                  <span
-                    class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
-                  >
-                    Kopioi virtuaaliviivakoodi
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
-            data-testid="carInfoCard"
-            role="region"
-          >
-            <h2
-              class="vehicle-details-header"
-            >
-              Ajoneuvon tiedot
-            </h2>
-            <div
-              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-            >
-              <label
-                class="FieldLabel-module_label__1zrXK "
-                for="regNumber"
-              >
-                Ajoneuvon rekisteritunnus
-              </label>
-              <div
-                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-              >
-                <input
-                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                  id="regNumber"
-                  readonly=""
-                  type="text"
-                  value="Esim. ABC-123"
-                />
-              </div>
-            </div>
-            <div
-              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-            >
-              <label
-                class="FieldLabel-module_label__1zrXK "
-                for="vehicleType"
-              >
-                Ajoneuvolaji
-              </label>
-              <div
-                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-              >
-                <input
-                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                  id="vehicleType"
-                  readonly=""
-                  type="text"
-                  value="Henkilöauto M1"
-                />
-              </div>
-            </div>
-            <div
-              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-            >
-              <label
-                class="FieldLabel-module_label__1zrXK "
-                for="vehicleBrand"
-              >
-                Merkki
-              </label>
-              <div
-                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-              >
-                <input
-                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                  id="vehicleBrand"
-                  readonly=""
-                  type="text"
-                  value="Citroen"
-                />
-              </div>
-            </div>
-            <div
-              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-            >
-              <label
-                class="FieldLabel-module_label__1zrXK "
-                for="vehicleModel"
-              >
-                Malli
-              </label>
-              <div
-                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-              >
-                <input
-                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                  id="vehicleModel"
-                  readonly=""
-                  type="text"
-                  value="2D C2 HATCHBACK 1.4l-JMKFVC/232"
-                />
-              </div>
-            </div>
-            <div
-              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-            >
-              <label
-                class="FieldLabel-module_label__1zrXK "
-                for="vehicleColor"
-              >
-                Väri
-              </label>
-              <div
-                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-              >
-                <input
-                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                  id="vehicleColor"
-                  readonly=""
-                  type="text"
-                  value="Punainen"
-                />
-              </div>
-            </div>
-            <div
-              class="imageViewer-preview-container"
-            >
-              <input
-                alt="Avaa kuvankatselu"
-                class="imageViewer-preview-image"
-                data-testid="clickable-image"
-                formmethod="dialog"
-                src="https://via.placeholder.com/600.png"
-                type="image"
-                value="0"
-              />
-              <input
-                alt="Avaa kuvankatselu"
-                class="imageViewer-preview-image"
-                data-testid="clickable-image"
-                formmethod="dialog"
-                src="https://via.placeholder.com/600x1200.png"
-                type="image"
-                value="1"
-              />
-              <input
-                alt="Avaa kuvankatselu"
-                class="imageViewer-preview-image"
-                data-testid="clickable-image"
-                formmethod="dialog"
-                src="https://via.placeholder.com/1200x800.png"
-                type="image"
-                value="2"
-              />
-            </div>
-          </div>
-        </div>
-        <button
-          aria-label="Sulje Pysäköintivirhemaksun tiedot"
-          class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
-          data-testid="summary-closeButton"
-          type="button"
+          aria-expanded="false"
+          aria-labelledby="fineSummary-heading"
+          class="Accordion-module_headingContainer__1DzX3"
+          role="button"
+          tabindex="0"
         >
           <span
-            class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+            class="label"
           >
-            Sulje
+            Pysäköintivirhemaksun tiedot
           </span>
-          <div
+          <svg
             aria-hidden="true"
-            class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
+            <g
+              fill="none"
+              fill-rule="evenodd"
             >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <path
-                  d="M0 24h24V0H0z"
-                />
-                <path
-                  d="M12 11.5l5 5 1.5-1.5L12 8.5 5.5 15 7 16.5z"
-                  fill="currentColor"
-                />
-              </g>
-            </svg>
-          </div>
-        </button>
+              <path
+                d="M0 0h24v24H0z"
+              />
+              <path
+                d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
       </div>
+    </div>
+    <div
+      aria-labelledby="fineSummary-heading"
+      class="Accordion-module_accordionContent__1umso Accordion-module_contentWithCloseButton__-einM"
+      id="fineSummary-content"
+      role="region"
+      style="display: none;"
+    >
+      <div
+        class="info-container"
+      >
+        <div
+          class="summary-body"
+        >
+          <div
+            class="summary-container"
+            data-testid="parkingFineSummary"
+          >
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineTimeStamp"
+              >
+                Virheen ajankohta
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineTimeStamp"
+                  readonly=""
+                  type="text"
+                  value="1.11.2019 09:41 - 1.11.2019 09:43"
+                />
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="refNumber"
+              >
+                Asianumero
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="refNumber"
+                  readonly=""
+                  type="text"
+                  value="Esim. 12345678"
+                />
+              </div>
+            </div>
+            <hr />
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="address"
+              >
+                Lähiosoite
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="address"
+                  readonly=""
+                  type="text"
+                  value="Näkinkuja 1c"
+                />
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="additionalDetails"
+              >
+                Lisätietoja
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="additionalDetails"
+                  readonly=""
+                  type="text"
+                  value="Kääntymispaikka"
+                />
+              </div>
+            </div>
+            <hr />
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineTitle-1"
+              >
+                Virhe
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <textarea
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineTitle-1"
+                  readonly=""
+                >
+                  Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+                </textarea>
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineDetails-1"
+              >
+                Lisätieto
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineDetails-1"
+                  readonly=""
+                  type="text"
+                  value="Liikennemerkistä n. 3 m"
+                />
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineTitle-2"
+              >
+                Virhe
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <textarea
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineTitle-2"
+                  readonly=""
+                >
+                  Pysäköinti kielletty liikennemerkin noudattamatta jättäminen. TLL 3 § 1 mom, TL 16 § merkki 372
+                </textarea>
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineDetails-2"
+              >
+                Lisätieto
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineDetails-2"
+                  readonly=""
+                  type="text"
+                  value="Liikennemerkistä n. 3 m"
+                />
+              </div>
+            </div>
+            <hr />
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq wide-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="fineAdditionalDetails"
+              >
+                Pysäköintivirheen lisätiedot
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <textarea
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="fineAdditionalDetails"
+                  readonly=""
+                >
+                  Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen. 294 merkkiä
+                </textarea>
+              </div>
+            </div>
+            <hr />
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field sum-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="sum"
+              >
+                Pysäköintivirhemaksun summa
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="sum"
+                  readonly=""
+                  type="text"
+                  value="80,00 EUR"
+                />
+              </div>
+            </div>
+            <div
+              class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq info-field"
+            >
+              <label
+                class="FieldLabel-module_label__1zrXK "
+                for="dueDate"
+              >
+                Eräpäivä
+              </label>
+              <div
+                class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+              >
+                <input
+                  class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                  id="dueDate"
+                  readonly=""
+                  type="text"
+                  value="2.12.2019"
+                />
+              </div>
+            </div>
+            <hr />
+            <div
+              class="barcode-container wide-field"
+            >
+              <label
+                class="barcode-label"
+              >
+                Virtuaaliviivakoodi
+              </label>
+              <p
+                class="barcode"
+              >
+                430123730001230560012400000000000000000100018714210302
+              </p>
+              <button
+                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS barcode-button"
+                data-testid="copy-to-clipboard"
+                type="button"
+              >
+                <div
+                  aria-hidden="true"
+                  class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                >
+                  <svg
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <rect
+                        height="24"
+                        width="24"
+                      />
+                      <path
+                        d="M6,10 L6,12 L5,12 L5,18 L12,18 L12,17 L14,17 L14,19 C14,19.5522847 13.5522847,20 13,20 L4,20 C3.44771525,20 3,19.5522847 3,19 L3,11 C3,10.4477153 3.44771525,10 4,10 L6,10 Z M20,4 C20.5522847,4 21,4.44771525 21,5 L21,15 C21,15.5522847 20.5522847,16 20,16 L8,16 C7.44771525,16 7,15.5522847 7,15 L7,5 C7,4.44771525 7.44771525,4 8,4 L20,4 Z M19,6 L9,6 L9,14 L19,14 L19,6 Z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </div>
+                <span
+                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                >
+                  Kopioi virtuaaliviivakoodi
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="Card-module_card__1WbKx card_hds-card--border__c2dBc custom-theme-1 vehicle-details-container"
+          data-testid="carInfoCard"
+          role="region"
+        >
+          <h2
+            class="vehicle-details-header"
+          >
+            Ajoneuvon tiedot
+          </h2>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="regNumber"
+            >
+              Ajoneuvon rekisteritunnus
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="regNumber"
+                readonly=""
+                type="text"
+                value="Esim. ABC-123"
+              />
+            </div>
+          </div>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="vehicleType"
+            >
+              Ajoneuvolaji
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="vehicleType"
+                readonly=""
+                type="text"
+                value="Henkilöauto M1"
+              />
+            </div>
+          </div>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="vehicleBrand"
+            >
+              Merkki
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="vehicleBrand"
+                readonly=""
+                type="text"
+                value="Citroen"
+              />
+            </div>
+          </div>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="vehicleModel"
+            >
+              Malli
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="vehicleModel"
+                readonly=""
+                type="text"
+                value="2D C2 HATCHBACK 1.4l-JMKFVC/232"
+              />
+            </div>
+          </div>
+          <div
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+          >
+            <label
+              class="FieldLabel-module_label__1zrXK "
+              for="vehicleColor"
+            >
+              Väri
+            </label>
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="vehicleColor"
+                readonly=""
+                type="text"
+                value="Punainen"
+              />
+            </div>
+          </div>
+          <div
+            class="imageViewer-preview-container"
+          >
+            <input
+              alt="Avaa kuvankatselu"
+              class="imageViewer-preview-image"
+              data-testid="clickable-image"
+              formmethod="dialog"
+              src="https://via.placeholder.com/600.png"
+              type="image"
+              value="0"
+            />
+            <input
+              alt="Avaa kuvankatselu"
+              class="imageViewer-preview-image"
+              data-testid="clickable-image"
+              formmethod="dialog"
+              src="https://via.placeholder.com/600x1200.png"
+              type="image"
+              value="1"
+            />
+            <input
+              alt="Avaa kuvankatselu"
+              class="imageViewer-preview-image"
+              data-testid="clickable-image"
+              formmethod="dialog"
+              src="https://via.placeholder.com/1200x800.png"
+              type="image"
+              value="2"
+            />
+          </div>
+        </div>
+      </div>
+      <button
+        aria-label="Sulje Pysäköintivirhemaksun tiedot"
+        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+        data-testid="fineSummary-closeButton"
+        type="button"
+      >
+        <span
+          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+        >
+          Sulje
+        </span>
+        <div
+          aria-hidden="true"
+          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+        >
+          <svg
+            aria-hidden="true"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <path
+                d="M0 24h24V0H0z"
+              />
+              <path
+                d="M12 11.5l5 5 1.5-1.5L12 8.5 5.5 15 7 16.5z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
 </div>

--- a/src/components/styles.module.css
+++ b/src/components/styles.module.css
@@ -149,3 +149,8 @@
     color: var(--color-black);
   }
 }
+
+.text-label {
+  font-size: var(--fontsize-body-m);
+  font-weight: 500;
+}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -217,6 +217,7 @@
     "toParkingService": "Pysäköinnin asiointikansiooni",
     "byMail": "Kirjeitse antamaani osoitteeseen",
     "attachments": "Liitetiedostot",
+    "poa": "Valtakirja",
     "attach-poa": "Liitä valtakirja"
   },
   "imageViewer": {

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import formContentReducer from './components/formContent/formContentSlice';
 import formStepperReducer from './components/formStepper/formStepperSlice';
 import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
+import rectificationFormReducer from './components/rectification/rectificationFormSlice';
 
 const store = configureStore({
   reducer: {
     formContent: formContentReducer,
     formStepper: formStepperReducer,
-    extendDueDateForm: extendDueDateFormReducer
+    extendDueDateForm: extendDueDateFormReducer,
+    rectificationForm: rectificationFormReducer
   }
 });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,7 @@ import { addDays, format, formatISO } from 'date-fns';
 
 const EXTENDEDDAYS = 30;
 const BREAKPOINT_M = 768;
+const BYTES_IN_KB = 1024;
 
 // from 'yyyy-mm-dd' to 'dd.mm.yyyy'
 export function formatDate(date: string): string {
@@ -35,3 +36,18 @@ export function isExtensionAllowed(date: string): boolean {
 export function isSmallScreen(width: number): boolean {
   return width < BREAKPOINT_M;
 }
+
+export const formatBytes = (bytes: number): string => {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const sizeUnits: string[] = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const sizeUnitIndex = Math.floor(Math.log(bytes) / Math.log(BYTES_IN_KB));
+  const sizeInUnit = bytes / BYTES_IN_KB ** sizeUnitIndex;
+  return `${
+    sizeUnitIndex < 2 || sizeInUnit % 1 === 0
+      ? Math.round(sizeInUnit)
+      : sizeInUnit.toFixed(1)
+  } ${sizeUnits[sizeUnitIndex]}`;
+};


### PR DESCRIPTION
This PR
* Saves the POA file and attachments to state
* Shows the files and attachments in the summary view of parking fine appeal form and moved car appeal form

TODO:
* Show added files on the FileInput component when e.g. the user goes to the 4th step and then comes back to the 3rd step (Requires changes by HDS first)
* Add some type of id to FileItem

<img width="1116" alt="Screenshot 2022-12-21 at 14 41 46" src="https://user-images.githubusercontent.com/36920208/208940625-a625edee-7b20-4474-8e92-cac29b25fb2c.png">



