### PR TITLE
Update buttons

### DIFF
--- a/src/components/formStepper/FormStepper.css
+++ b/src/components/formStepper/FormStepper.css
@@ -58,7 +58,10 @@
     justify-content: space-between;
     margin-top: 12px;
   }
+}
 
+.button {
+  height: 56px;
 }
 
 .button.submit {
@@ -72,4 +75,8 @@
 
 .button.back {
   width: 100%;
+}
+
+.button.link {
+  text-decoration: none;
 }

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -105,13 +105,13 @@ const FormStepper = (props: Props): React.ReactElement => {
             </a>
           )}
           <div>
-            {lastStep && formContent.selectedForm === 'parking-fine' && (
+            {lastStep && formContent.selectedForm !== 'due-date' && (
               <Button
                 iconLeft={<IconPrinter />}
                 onClick={() => null}
                 variant="secondary"
                 className="button print">
-                Tulosta
+                {t('common:print')}
               </Button>
             )}
             {!lastStep ? (

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   IconArrowLeft,
   IconArrowRight,
+  IconHome,
   IconPrinter,
   IconThumbsUp,
   Notification,
@@ -92,6 +93,17 @@ const FormStepper = (props: Props): React.ReactElement => {
             variant="secondary">
             {t('common:previous')}
           </Button>
+          {activeStepIndex === 1 && !lastStep && (
+            <a className="button link" href="/">
+              <Button
+                className="button"
+                iconRight={<IconHome />}
+                role="link"
+                variant="secondary">
+                {t('common:to-mainpage')}
+              </Button>
+            </a>
+          )}
           <div>
             {lastStep && formContent.selectedForm === 'parking-fine' && (
               <Button
@@ -108,7 +120,9 @@ const FormStepper = (props: Props): React.ReactElement => {
                 iconRight={<IconArrowRight />}
                 onClick={() => dispatch(completeStep(activeStepIndex))}
                 variant="primary">
-                {t('common:next')}
+                {activeStepIndex === 1
+                  ? t('common:make-rectification')
+                  : t('common:next')}
               </Button>
             ) : formContent.formSubmitted ? (
               <Button
@@ -147,8 +161,12 @@ const FormStepper = (props: Props): React.ReactElement => {
         <div>
           {lastStep && formContent.formSubmitted && (
             <div ref={mainPageButtonRef}>
-              <a href="/">
-                <Button className="button back" role="link" variant="primary">
+              <a className="button link" href="/">
+                <Button
+                  className="button back"
+                  iconRight={<IconHome />}
+                  role="link"
+                  variant="primary">
                   {t('common:to-mainpage')}
                 </Button>
               </a>

--- a/src/components/rectification/RectificationForm.tsx
+++ b/src/components/rectification/RectificationForm.tsx
@@ -3,13 +3,10 @@ import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
-  Button,
   Checkbox,
   FileInput,
   IconCheckCircle,
-  IconUploadCloud,
   Link,
-  Notification,
   RadioButton,
   Select,
   SelectionGroup,
@@ -35,9 +32,6 @@ const RectificationForm = () => {
   const [newEmailSelected, setNewEmailSelected] = useState(false);
   const [vehicleRelation, setVehicleRelation] = useState('driver');
   const [currentCharacters, setCurrentCharacters] = useState(0);
-  const [showDraftSavedNotification, setShowDraftSavedNotification] = useState(
-    false
-  );
 
   const [decision, setDecision] = useState('toParkingService');
 
@@ -52,10 +46,6 @@ const RectificationForm = () => {
 
   const handleDecision = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDecision(e.target.value);
-  };
-
-  const handleDraftSave = () => {
-    setShowDraftSavedNotification(true);
   };
 
   const setFiles = (files: File[], type: string) => {
@@ -276,27 +266,6 @@ const RectificationForm = () => {
               checked={decision === 'byMail'}
             />
           </SelectionGroup>
-        </div>
-        <div>
-          <Button
-            className="rectification-draft-button"
-            iconLeft={<IconUploadCloud />}
-            onClick={handleDraftSave}
-            variant="secondary">
-            {t('common:save-draft')}
-          </Button>
-          {showDraftSavedNotification && (
-            <Notification
-              label={t('common:notifications:draft-saved:label')}
-              position="bottom-right"
-              type={'success'}
-              autoClose
-              dismissible
-              closeButtonLabelText="Close notification"
-              onClose={() => setShowDraftSavedNotification(false)}>
-              {t('common:notifications:draft-saved:text')}
-            </Notification>
-          )}
         </div>
       </div>
     </>

--- a/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectification/__snapshots__/RectificationForm.test.tsx.snap
@@ -920,43 +920,6 @@ exports[`Component in moved car form matches snapshot 1`] = `
         </div>
       </fieldset>
     </div>
-    <div>
-      <button
-        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS rectification-draft-button"
-        type="button"
-      >
-        <div
-          aria-hidden="true"
-          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
-        >
-          <svg
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M7.5,12 L12,7.5 L16.5,12 L15,13.5 L13,11.5 L13,22 L11,22 L11,11.5 L9,13.5 L7.5,12 Z M11.5,2 C14.0570069,2 16.3672564,3.55157482 17.2358321,5.93092178 L17.2835,6.0665 L17.4145183,6.08731097 C20.0449239,6.53520702 21.9316381,8.61876864 21.9981819,11.350367 L22,11.5 C22,14.6411668 19.7996323,16.9265021 16.7006468,16.998261 L16.55,17 L15.5,17 L15.5,15 L16.55,15 C18.6163623,15 20,13.5942857 20,11.5 C20,9.538055 18.6018237,8.11877635 16.6000787,8.00507103 L16.4714957,7.99959367 L15.6755756,7.97689732 L15.5194193,7.19611614 C15.1395428,5.29673328 13.433695,4 11.5,4 C9.26285888,4 7.62213728,5.5585359 7.5065992,7.75063225 L7.50156899,7.88030287 L7.48772078,8.99175409 L6.33061979,9.0012438 C4.84064582,9.04438683 3.6,10.4529679 3.6,12.1 C3.6,13.6643787 4.83868693,14.9394465 6.38876321,14.9979059 L6.5,15 L8.5,15 L8.5,17 L6.5,17 C3.79380473,17 1.6,14.8061953 1.6,12.1 C1.6,9.68983052 3.25231852,7.56452435 5.49502278,7.09571076 L5.5645,7.082 L5.58684851,6.93675031 C6.05502185,4.09688845 8.36434526,2.06966277 11.3452237,2.00175907 L11.5,2 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-        </div>
-        <span
-          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
-        >
-          Tallenna keskeneräisenä
-        </span>
-      </button>
-    </div>
   </div>
 </div>
 `;
@@ -1753,43 +1716,6 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
           </div>
         </div>
       </fieldset>
-    </div>
-    <div>
-      <button
-        class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS rectification-draft-button"
-        type="button"
-      >
-        <div
-          aria-hidden="true"
-          class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
-        >
-          <svg
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M7.5,12 L12,7.5 L16.5,12 L15,13.5 L13,11.5 L13,22 L11,22 L11,11.5 L9,13.5 L7.5,12 Z M11.5,2 C14.0570069,2 16.3672564,3.55157482 17.2358321,5.93092178 L17.2835,6.0665 L17.4145183,6.08731097 C20.0449239,6.53520702 21.9316381,8.61876864 21.9981819,11.350367 L22,11.5 C22,14.6411668 19.7996323,16.9265021 16.7006468,16.998261 L16.55,17 L15.5,17 L15.5,15 L16.55,15 C18.6163623,15 20,13.5942857 20,11.5 C20,9.538055 18.6018237,8.11877635 16.6000787,8.00507103 L16.4714957,7.99959367 L15.6755756,7.97689732 L15.5194193,7.19611614 C15.1395428,5.29673328 13.433695,4 11.5,4 C9.26285888,4 7.62213728,5.5585359 7.5065992,7.75063225 L7.50156899,7.88030287 L7.48772078,8.99175409 L6.33061979,9.0012438 C4.84064582,9.04438683 3.6,10.4529679 3.6,12.1 C3.6,13.6643787 4.83868693,14.9394465 6.38876321,14.9979059 L6.5,15 L8.5,15 L8.5,17 L6.5,17 C3.79380473,17 1.6,14.8061953 1.6,12.1 C1.6,9.68983052 3.25231852,7.56452435 5.49502278,7.09571076 L5.5645,7.082 L5.58684851,6.93675031 C6.05502185,4.09688845 8.36434526,2.06966277 11.3452237,2.00175907 L11.5,2 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-        </div>
-        <span
-          class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
-        >
-          Tallenna keskeneräisenä
-        </span>
-      </button>
     </div>
   </div>
 </div>

--- a/src/components/reimbursement/ReimbursementSummary.tsx
+++ b/src/components/reimbursement/ReimbursementSummary.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { setSubmitDisabled } from '../formContent/formContentSlice';
 import Barcode from '../barcode/Barcode';
 import './ReimbursementSummary.css';
 
 const ReimbursementSummary = (): React.ReactElement => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setSubmitDisabled(false));
+  }, [dispatch]);
 
   return (
     <div className="summary-body">

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -9,6 +9,7 @@
     "fetched-from-profile-aria": "Tieto haettu Helsinki-profiilista",
     "previous": "Edellinen",
     "next": "Seuraava",
+    "make-rectification": "Tee oikaisuvaatimus",
     "save-draft": "Tallenna keskeneräisenä",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
@@ -159,6 +160,13 @@
       "step4": "Yhteenveto"
     },
     "submit": "Lähetä",
+    "submit-success": "Lähetys onnistui",
+    "notifications": {
+      "success": {
+        "label": "Olemme vastaanottaneet oikaisuvaatimuksesi",
+        "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
+      }
+    },
     "move-timestamp": {
       "label": "Siirron päivämäärä",
       "placeholder": "1.11.2019"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -10,7 +10,6 @@
     "previous": "Edellinen",
     "next": "Seuraava",
     "make-rectification": "Tee oikaisuvaatimus",
-    "save-draft": "Tallenna keskeneräisenä",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -10,6 +10,7 @@
     "previous": "Edellinen",
     "next": "Seuraava",
     "make-rectification": "Tee oikaisuvaatimus",
+    "print": "Tulosta",
     "required-fields": "Pakolliset kentät on merkitty tähdellä *",
     "email-confirmation": "Haluan vahvistuksen sähköpostiini",
     "helsinki-profile-link": "Siirry Helsinki-profiiliin muokataksesi tietoja.",


### PR DESCRIPTION
This PR:
* Removes "save as draft" button from rectification form
* Adds "go to main page" button to rectification summary
* Changes "next" button text to "create a rectification" on rectification summary
* Adds the "print" button to the summary view of moved car appeal form