### PR TITLE
Fix ImageViewer styling

### DIFF
--- a/src/components/imageViewer/ImageViewer.css
+++ b/src/components/imageViewer/ImageViewer.css
@@ -9,25 +9,25 @@
   width: 95vw !important;
 }
 
-@media (max-width: 767px) {
-  .imageViewer-dialog div:nth-child(2) {
-    height: 60vh;
-    width: 80vw;
-    margin: 0 auto;
-    text-align: center;
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    justify-content: center;
-    gap: var(--spacing-xs);
-    overflow-y: auto;
-  }
+.imageViewer-dialog div:nth-child(2) {
+  height: 67vh;
+  width: 80vw;
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  overflow-y: auto;
+}
 
-  .imageViewer-dialog img {
-    max-height: 90%;
-    max-width: 100%;
-  }
+.imageViewer-dialog img {
+  max-height: 90%;
+  max-width: 100%;
+}
 
+@media (max-width: 768px) {
   .imageViewer-button-container {
     display: flex;
     flex-direction: column-reverse;

--- a/src/components/imageViewer/ImageViewer.css
+++ b/src/components/imageViewer/ImageViewer.css
@@ -5,13 +5,35 @@
 }
 
 .imageViewer-dialog {
-  width: auto !important;
+  height: 90vh !important;
+  width: 95vw !important;
 }
 
-.imageViewer-dialog-image {
-  max-height: 800px;
-  max-width: 800px;
-  display: inline-block;
+@media (max-width: 767px) {
+  .imageViewer-dialog div:nth-child(2) {
+    height: 60vh;
+    width: 80vw;
+    margin: 0 auto;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--spacing-xs);
+    overflow-y: auto;
+  }
+
+  .imageViewer-dialog img {
+    max-height: 90%;
+    max-width: 100%;
+  }
+
+  .imageViewer-button-container {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: var(--spacing-xs);
+    padding-top: 0;
+  }
 }
 
 .imageViewer-preview-image {

--- a/src/components/imageViewer/ImageViewer.css
+++ b/src/components/imageViewer/ImageViewer.css
@@ -10,8 +10,8 @@
 }
 
 .imageViewer-dialog div:nth-child(2) {
-  height: 67vh;
-  width: 80vw;
+  height: 100%;
+  width: 80%;
   margin: 0 auto;
   text-align: center;
   display: flex;

--- a/src/components/imageViewer/ImageViewer.tsx
+++ b/src/components/imageViewer/ImageViewer.tsx
@@ -59,7 +59,7 @@ const ImageViewer = (props: ImageViewerProps) => {
             {t('imageViewer:image')} {currentImage + 1} / {images.length}
           </span>
         </Dialog.Content>
-        <Dialog.ActionButtons>
+        <Dialog.ActionButtons className="imageViewer-button-container">
           <Button onClick={previousImage} disabled={currentImage === 0}>
             {t('imageViewer:previous-image')}
           </Button>


### PR DESCRIPTION
This PR fixes the responsiveness issues of ImageViewer component.

Mobile view:
<img width="345" alt="Screenshot 2023-01-04 at 9 48 38" src="https://user-images.githubusercontent.com/36920208/210509376-a74c100c-6781-45c7-81f3-fcabd53e9891.png">

Desktop view:
<img width="991" alt="Screenshot 2023-01-04 at 9 48 02" src="https://user-images.githubusercontent.com/36920208/210509392-9060a2b3-e754-466a-80e4-8a54a7451277.png">
