### PR TITLE
Fix accordion header on moved car form

### DIFF
--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -152,7 +152,11 @@ const RectificationSummary = () => {
       </div>
       <Accordion
         id="fineSummary"
-        heading={t('parking-fine:fine-info')}
+        heading={
+          selectedForm === FormId.MOVEDCAR
+            ? t('moved-car:stepper:step2')
+            : t('parking-fine:fine-info')
+        }
         className="rectification-summary-fine-details">
         <InfoContainer />
       </Accordion>

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`Component matches snapshot 1`] = `
           class="text-label"
           for="rectification-content"
         >
-          rectificationForm-content
+          rectification-content
         </label>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse bibendum condimentum mi, vitae efficitur mi vulputate at. Aliquam porttitor tincidunt ex non fermentum. Fusce consequat imperdiet augue ut pulvinar. Praesent sollicitudin nulla non lacus tristique, sed faucibus urna viverra. Nullam pretium velit lorem. Maecenas porttitor molestie.


### PR DESCRIPTION
This PR changes the accordion header from "parking fine summary" to "reimbursement summary" on summary view of moved car form.