### PR TITLE
Fix FileInput mobile styling

### DIFF
--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -11,7 +11,8 @@ import {
   Stepper
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { formatDate, isSmallScreen } from '../../utils/helpers';
+import { formatDate } from '../../utils/helpers';
+import useMobileWidth from '../../hooks/useMobileWidth';
 import FormContent from '../formContent/FormContent';
 import {
   completeStep,
@@ -41,20 +42,6 @@ const FormStepper = (props: Props): React.ReactElement => {
   const lastStep = activeStepIndex === steps.length - 1;
   const [showSubmitNotification, setShowSubmitNotification] = useState(false);
   const mainPageButtonRef = useRef<null | HTMLDivElement>(null);
-  const [screenWidth, setScreenWidth] = useState(window.innerWidth);
-
-  // save the screen size on window resize event, to decide the size of stepper component
-  useEffect(() => {
-    function handleResize() {
-      setScreenWidth(window.innerWidth);
-    }
-
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
 
   const handleSubmit = () => {
     dispatch(setFormSubmitted(true));
@@ -83,7 +70,7 @@ const FormStepper = (props: Props): React.ReactElement => {
       <div id="stepper">
         <Stepper
           className="stepper hide-on-print"
-          small={isSmallScreen(screenWidth)}
+          small={useMobileWidth()}
           language="fi"
           onStepClick={(event, stepIndex) => dispatch(setActive(stepIndex))}
           selectedStep={activeStepIndex}

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -14,6 +14,7 @@ import {
   TextInput
 } from 'hds-react';
 import { useClient } from '../../client/hooks';
+import useMobileWidth from '../../hooks/useMobileWidth';
 import { FormId, selectFormContent } from '../formContent/formContentSlice';
 import { FileItem, setAttachments, setPOAFile } from './rectificationFormSlice';
 import './RectificationForm.css';
@@ -130,14 +131,24 @@ const RectificationForm = () => {
             </div>
           </div>
           <div className="rectification-poa-fileinput">
-            <FileInput
-              language={i18n.language as Language}
-              label={t('rectificationForm:attach-poa')}
-              id="rectificationPOAFile"
-              onChange={e => setFiles(e, 'poa')}
-              dragAndDrop
-              accept={'.png, .jpg, .pdf'}
-            />
+            {useMobileWidth() ? (
+              <FileInput
+                language={i18n.language as Language}
+                label={t('rectificationForm:attach-poa')}
+                id="rectificationPOAFile"
+                onChange={e => setFiles(e, 'poa')}
+                accept={'.png, .jpg, .pdf'}
+              />
+            ) : (
+              <FileInput
+                language={i18n.language as Language}
+                label={t('rectificationForm:attach-poa')}
+                id="rectificationPOAFile"
+                onChange={e => setFiles(e, 'poa')}
+                dragAndDrop
+                accept={'.png, .jpg, .pdf'}
+              />
+            )}
           </div>
         </div>
         <hr />
@@ -238,16 +249,28 @@ const RectificationForm = () => {
             }
           />
 
-          <FileInput
-            language={i18n.language as Language}
-            multiple
-            className="rectification-fileinput"
-            label={t('rectificationForm:attachments')}
-            id="rectificationAttachments"
-            onChange={e => setFiles(e, 'attachments')}
-            dragAndDrop
-            accept={'.png, .jpg, .pdf'}
-          />
+          {useMobileWidth() ? (
+            <FileInput
+              language={i18n.language as Language}
+              multiple
+              className="rectification-fileinput"
+              label={t('rectificationForm:attachments')}
+              id="rectificationAttachments"
+              onChange={e => setFiles(e, 'attachments')}
+              accept={'.png, .jpg, .pdf'}
+            />
+          ) : (
+            <FileInput
+              language={i18n.language as Language}
+              multiple
+              className="rectification-fileinput"
+              label={t('rectificationForm:attachments')}
+              id="rectificationAttachments"
+              onChange={e => setFiles(e, 'attachments')}
+              dragAndDrop
+              accept={'.png, .jpg, .pdf'}
+            />
+          )}
 
           <SelectionGroup
             label={t('rectificationForm:decision-choice')}

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -131,24 +131,14 @@ const RectificationForm = () => {
             </div>
           </div>
           <div className="rectification-poa-fileinput">
-            {useMobileWidth() ? (
-              <FileInput
-                language={i18n.language as Language}
-                label={t('rectificationForm:attach-poa')}
-                id="rectificationPOAFile"
-                onChange={e => setFiles(e, 'poa')}
-                accept={'.png, .jpg, .pdf'}
-              />
-            ) : (
-              <FileInput
-                language={i18n.language as Language}
-                label={t('rectificationForm:attach-poa')}
-                id="rectificationPOAFile"
-                onChange={e => setFiles(e, 'poa')}
-                dragAndDrop
-                accept={'.png, .jpg, .pdf'}
-              />
-            )}
+            <FileInput
+              language={i18n.language as Language}
+              label={t('rectificationForm:attach-poa')}
+              id="rectificationPOAFile"
+              onChange={e => setFiles(e, 'poa')}
+              dragAndDrop={!useMobileWidth()}
+              accept={'.png, .jpg, .pdf'}
+            />
           </div>
         </div>
         <hr />
@@ -249,28 +239,16 @@ const RectificationForm = () => {
             }
           />
 
-          {useMobileWidth() ? (
-            <FileInput
-              language={i18n.language as Language}
-              multiple
-              className="rectification-fileinput"
-              label={t('rectificationForm:attachments')}
-              id="rectificationAttachments"
-              onChange={e => setFiles(e, 'attachments')}
-              accept={'.png, .jpg, .pdf'}
-            />
-          ) : (
-            <FileInput
-              language={i18n.language as Language}
-              multiple
-              className="rectification-fileinput"
-              label={t('rectificationForm:attachments')}
-              id="rectificationAttachments"
-              onChange={e => setFiles(e, 'attachments')}
-              dragAndDrop
-              accept={'.png, .jpg, .pdf'}
-            />
-          )}
+          <FileInput
+            language={i18n.language as Language}
+            multiple
+            className="rectification-fileinput"
+            label={t('rectificationForm:attachments')}
+            id="rectificationAttachments"
+            onChange={e => setFiles(e, 'attachments')}
+            dragAndDrop={!useMobileWidth()}
+            accept={'.png, .jpg, .pdf'}
+          />
 
           <SelectionGroup
             label={t('rectificationForm:decision-choice')}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,6 @@
 import { addDays, format, formatISO } from 'date-fns';
 
 const EXTENDEDDAYS = 30;
-const BREAKPOINT_M = 768;
 const BYTES_IN_KB = 1024;
 
 // from 'yyyy-mm-dd' to 'dd.mm.yyyy'
@@ -31,10 +30,6 @@ function isInFuture(date: string): boolean {
 // due date is not allowed
 export function isExtensionAllowed(date: string): boolean {
   return isInFuture(date);
-}
-
-export function isSmallScreen(width: number): boolean {
-  return width < BREAKPOINT_M;
 }
 
 export const formatBytes = (bytes: number): string => {


### PR DESCRIPTION
This PR:
* Removes the unnecessary drag and drop option from FileInput when on mobile screen
* Refactors code relating to screen width hook

<img width="373" alt="Screenshot 2023-01-11 at 9 53 46" src="https://user-images.githubusercontent.com/36920208/211754809-9466b5ac-a4ce-4b80-87d9-96817740599b.png">
