### PR TITLE
Add state handling to SearchForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prettier": "^1.18.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.41.5",
     "react-i18next": "^12.0.0",
     "react-redux": "^8.0.2",
     "react-router": "^5.3.3",
@@ -80,6 +81,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/jest-axe": "^3.5.5",
     "cross-env": "^7.0.3",
     "husky": "^8.0.2",

--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -30,9 +30,7 @@ const ExtendDueDate = (): React.ReactElement => {
 
   return (
     <PageContent>
-      <form>
-        <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
-      </form>
+      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
     </PageContent>
   );
 };

--- a/src/components/formContent/FormContent.test.tsx
+++ b/src/components/formContent/FormContent.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useForm } from 'react-hook-form';
 import { axe } from 'jest-axe';
 import FormContent from './FormContent';
-import { Provider } from 'react-redux';
+import { RectificationFormType } from '../../interfaces/formInterfaces';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import store from '../../store';
 import '@testing-library/jest-dom';
-
 const extendDueDateFormSliceMock = createSlice({
   name: 'extendDueDateForm',
   initialState: {
@@ -47,11 +49,23 @@ const movedCarFormContentSliceMock = createSlice({
   reducers: {}
 });
 
+const { result } = renderHook(() =>
+  useForm<RectificationFormType>({
+    defaultValues: {
+      invoiceNumber: '',
+      refNumber: '',
+      regNumber: ''
+    }
+  })
+);
+
+const control = result.current.control;
+
 describe('form content', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
       <Provider store={store}>
-        <FormContent activeStep={0} />
+        <FormContent activeStep={0} control={control} />
       </Provider>
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -68,7 +82,7 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} />
+            <FormContent activeStep={0} control={control} />
           </Provider>
         );
 
@@ -83,7 +97,7 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} />
+            <FormContent activeStep={0} control={control} />
           </Provider>
         );
         await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
@@ -97,7 +111,7 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} />
+            <FormContent activeStep={0} control={control} />
           </Provider>
         );
         await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
@@ -114,7 +128,7 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} />
+            <FormContent activeStep={1} control={control} />
           </Provider>
         );
 
@@ -132,7 +146,7 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} />
+            <FormContent activeStep={1} control={control} />
           </Provider>
         );
 
@@ -149,7 +163,7 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} />
+            <FormContent activeStep={1} control={control} />
           </Provider>
         );
         await waitFor(() =>

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import SearchForm from '../searchForm/SearchForm';
 import { FormId, selectFormContent } from './formContentSlice';
-import './FormContent.css';
 import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
 import InfoContainer from '../infoContainer/InfoContainer';
 import RectificationForm from '../rectificationForm/RectificationForm';
 import RectificationSummary from '../rectificationSummary/RectificationSummary';
+import { RectificationControlType } from '../../interfaces/formInterfaces';
+import './FormContent.css';
 
 interface Props {
   activeStep: number;
+  control: RectificationControlType;
 }
 
 const FormContent = (props: Props): React.ReactElement => {
@@ -30,7 +32,7 @@ const FormContent = (props: Props): React.ReactElement => {
     <div className="form-container">
       {
         {
-          0: <SearchForm />,
+          0: <SearchForm control={props.control} />,
           1: selectForm(formContent.selectedForm),
           2: <RectificationForm />,
           3: <RectificationSummary />

--- a/src/components/movedCarAppeal/MovedCarAppeal.tsx
+++ b/src/components/movedCarAppeal/MovedCarAppeal.tsx
@@ -38,9 +38,7 @@ const MovedCarAppeal = (): React.ReactElement => {
 
   return (
     <PageContent>
-      <form>
-        <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
-      </form>
+      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
     </PageContent>
   );
 };

--- a/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
+++ b/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
@@ -38,9 +38,7 @@ const ParkingFineAppeal = (): React.ReactElement => {
 
   return (
     <PageContent>
-      <form>
-        <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
-      </form>
+      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
     </PageContent>
   );
 };

--- a/src/components/searchForm/SearchForm.tsx
+++ b/src/components/searchForm/SearchForm.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { Controller } from 'react-hook-form';
 import { TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { FormId, selectFormContent } from '../formContent/formContentSlice';
+import { RectificationControlType } from '../../interfaces/formInterfaces';
 import './SearchForm.css';
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
-const SearchForm = (): React.ReactElement => {
+interface Props {
+  control: RectificationControlType;
+}
+
+const SearchForm = (props: Props): React.ReactElement => {
   const { t } = useTranslation();
   const formContent = useSelector(selectFormContent);
   const movedCarForm = formContent.selectedForm == FormId.MOVEDCAR;
@@ -14,37 +21,69 @@ const SearchForm = (): React.ReactElement => {
     <div data-testid="searchForm" className="fieldset">
       <p className="small-text">{t('common:required-fields')}</p>
       {movedCarForm ? (
-        <TextInput
-          className="field"
-          id="invoiceNumber"
-          label={t('common:fine-info:invoice-number:label')}
-          placeholder={t('common:fine-info:invoice-number:placeholder')}
-          tooltipLabel={t('common:fine-info:invoice-number:label')}
-          tooltipText={t('common:fine-info:invoice-number:tooltip-text')}
-          required
+        <Controller
+          name="invoiceNumber"
+          control={props.control}
+          rules={{
+            required: t('common:fine-info:invoice-number:error') as string
+          }}
+          render={({ field, fieldState }) => (
+            <TextInput
+              {...field}
+              className="field"
+              id="invoiceNumber"
+              label={t('common:fine-info:invoice-number:label')}
+              placeholder={t('common:fine-info:invoice-number:placeholder')}
+              tooltipLabel={t('common:fine-info:invoice-number:label')}
+              tooltipText={t('common:fine-info:invoice-number:tooltip-text')}
+              required
+              invalid={fieldState.error ? true : false}
+              errorText={fieldState.error?.message}
+            />
+          )}
         />
       ) : (
-        <TextInput
-          className="field"
-          id="refNumber"
-          label={t('common:fine-info:ref-number:label')}
-          placeholder={t('common:fine-info:ref-number:placeholder')}
-          tooltipLabel={t('common:fine-info:ref-number:label')}
-          tooltipText={t('common:fine-info:ref-number:tooltip-text')}
-          required
+        <Controller
+          name="refNumber"
+          control={props.control}
+          rules={{ required: t('common:fine-info:ref-number:error') as string }}
+          render={({ field, fieldState }) => (
+            <TextInput
+              {...field}
+              className="field"
+              id="refNumber"
+              label={t('common:fine-info:ref-number:label')}
+              placeholder={t('common:fine-info:ref-number:placeholder')}
+              tooltipLabel={t('common:fine-info:ref-number:label')}
+              tooltipText={t('common:fine-info:ref-number:tooltip-text')}
+              required
+              invalid={fieldState.error ? true : false}
+              errorText={fieldState.error?.message}
+            />
+          )}
         />
       )}
-      <TextInput
-        className="field"
-        id="regNumber"
-        label={t('common:fine-info:reg-number:label')}
-        placeholder={t('common:fine-info:reg-number:placeholder')}
-        helperText={
-          movedCarForm
-            ? t('common:fine-info:reg-number:helper-text:moved-car')
-            : t('common:fine-info:reg-number:helper-text:common')
-        }
-        required
+      <Controller
+        name="regNumber"
+        control={props.control}
+        rules={{ required: t('common:fine-info:reg-number:error') as string }}
+        render={({ field, fieldState }) => (
+          <TextInput
+            {...field}
+            className="field"
+            id="regNumber"
+            label={t('common:fine-info:reg-number:label')}
+            placeholder={t('common:fine-info:reg-number:placeholder')}
+            helperText={
+              movedCarForm
+                ? t('common:fine-info:reg-number:helper-text:moved-car')
+                : t('common:fine-info:reg-number:helper-text:common')
+            }
+            required
+            invalid={fieldState.error ? true : false}
+            errorText={fieldState.error?.message}
+          />
+        )}
       />
     </div>
   );

--- a/src/components/searchForm/searchFormSlice.tsx
+++ b/src/components/searchForm/searchFormSlice.tsx
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+export type SearchState = {
+  invoiceNumber: string;
+  refNumber: string;
+  regNumber: string;
+};
+
+const initialState: SearchState = {
+  invoiceNumber: '',
+  refNumber: '',
+  regNumber: ''
+};
+
+export const slice = createSlice({
+  name: 'searchForm',
+  initialState,
+  reducers: {
+    setSearchFormValues: (state, action) => ({ ...state, ...action.payload })
+  }
+});
+
+// Actions
+export const { setSearchFormValues } = slice.actions;
+
+// Selectors
+export const selectSearchFormValues = (state: RootState) => state.searchForm;
+
+export default slice.reducer;

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -30,6 +30,7 @@ const useUserProfile = () => {
     if (!profile) {
       fetchProfile();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return profile;

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -39,12 +39,14 @@
       "ref-number": {
         "label": "Asianumero",
         "placeholder": "Esim. 12345678",
-        "tooltip-text": "Asianumeron löydät pysäköintivirhemaksusta"
+        "tooltip-text": "Asianumeron löydät pysäköintivirhemaksusta",
+        "error": "Tarkista asianumero. Kirjoita muodossa 12345678."
       },
       "invoice-number": {
         "label": "Korvauspäätöksen laskun numero",
         "placeholder": "Esim. 12345678",
-        "tooltip-text": "Laskun numeron löydät sinulle lähetetystä korvauspäätöksestä."
+        "tooltip-text": "Laskun numeron löydät sinulle lähetetystä korvauspäätöksestä.",
+        "error": "Tarkista laskun numero. Kirjoita muodossa 12345678."
       },
       "reg-number": {
         "label": "Ajoneuvon rekisteritunnus",
@@ -52,7 +54,8 @@
         "helper-text": {
           "common": "Kirjoita rekisteritunnus kuten se on pysäköintivirhemaksussa.",
           "moved-car": "Kirjoita rekisteritunnus kuten se on korvauspäätöksessä."
-        }
+        },
+        "error": "Tarkista rekisteritunnus. Kirjoita muodossa ABC-123."
       },
       "fine-timestamp": {
         "label": "Virheen ajankohta",

--- a/src/interfaces/formInterfaces.ts
+++ b/src/interfaces/formInterfaces.ts
@@ -1,0 +1,6 @@
+import { Control } from 'react-hook-form';
+import { SearchState } from '../components/searchForm/searchFormSlice';
+
+export type RectificationFormType = SearchState;
+
+export type RectificationControlType = Control<RectificationFormType>;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -3,13 +3,15 @@ import formContentReducer from './components/formContent/formContentSlice';
 import formStepperReducer from './components/formStepper/formStepperSlice';
 import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
 import rectificationFormReducer from './components/rectificationForm/rectificationFormSlice';
+import searchFormReducer from './components/searchForm/searchFormSlice';
 
 const store = configureStore({
   reducer: {
     formContent: formContentReducer,
     formStepper: formStepperReducer,
     extendDueDateForm: extendDueDateFormReducer,
-    rectificationForm: rectificationFormReducer
+    rectificationForm: rectificationFormReducer,
+    searchForm: searchFormReducer
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,6 +2828,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.1.5":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
@@ -9444,6 +9452,13 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -9453,6 +9468,11 @@ react-fast-compare@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-hook-form@^7.41.5:
+  version "7.41.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.5.tgz#dcd0e7438c15044eadc99df6deb889da5858a03b"
+  integrity sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==
 
 react-i18next@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
This PR:
* Starts using react-hook-form as the library for form state handling (with redux)
* Adds state handling to the first view of all forms (SearchForm)
* Adds validation rules which state that all the fields of SearchForm are required (other validation should be done later)

<img width="340" alt="Screenshot 2023-01-13 at 16 14 40" src="https://user-images.githubusercontent.com/36920208/212341321-09843ac9-056a-49da-9ea6-b0ac0013019d.png">

