### PR TITLE
Fix user info fields on RectificationForm

### DIFF
--- a/src/components/fieldLabel/FieldLabel.css
+++ b/src/components/fieldLabel/FieldLabel.css
@@ -1,5 +1,4 @@
 .field-label {
   font-size: var(--fontsize-body-m);
   font-weight: 500;
-  margin-bottom: var(--spacing-s);
 }

--- a/src/components/rectificationForm/RectificationForm.css
+++ b/src/components/rectificationForm/RectificationForm.css
@@ -34,13 +34,20 @@
 }
 
 .rectification-form-user-details {
-  margin-top: var(--spacing-xl);
-  display: grid;
-  grid-template-rows: repeat(3, auto);
+  display: inline-flex;
+  flex-direction: column;
+  margin-top: 2rem;
+  min-width: 200px;
+  max-width: 400px;
 }
 
-.rectification-fileinput {
-  grid-column: 1 / 3;
+.rectification-form-user-details div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.rectification-form-user-details p {
+  overflow-wrap: break-word;
 }
 
 .rectification-fileinput div:first-of-type {
@@ -76,10 +83,6 @@
     margin-bottom: var(--spacing-2-xl);
   }
 
-  .rectification-form-user-details {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .rectification-poa-fileinput {
     flex: 1;
     min-width: 300px;
@@ -103,14 +106,6 @@
 }
 
 @media only screen and (min-width: 768px) {
-  .rectification-form-user-details {
-    grid-template-columns: 1fr 3fr;
-  }
-
-  .rectification-form-user-details.small {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .rectification-poa-fileinput {
     flex: 1;
     margin-top: 5px;
@@ -124,6 +119,16 @@
   gap: var(--spacing-xs);
 }
 
+.radio-group-container label {
+  font-weight: normal;
+}
+
 .small-text {
   font-size: var(--fontsize-body-m);
+}
+
+@media (max-width: 450px) {
+  .rectification-form-user-details {
+    max-width: 90vw;
+  }
 }

--- a/src/components/rectificationForm/RectificationForm.css
+++ b/src/components/rectificationForm/RectificationForm.css
@@ -48,6 +48,7 @@
 
 .rectification-form-user-details p {
   overflow-wrap: break-word;
+  margin-bottom: var(--spacing-m);
 }
 
 .rectification-fileinput div:first-of-type {
@@ -111,6 +112,10 @@
     margin-top: 5px;
     min-width: 450px;
   }
+}
+
+.radio-group-section .field-label {
+  margin-bottom: var(--spacing-s);
 }
 
 .radio-group-container {

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -99,43 +99,31 @@ const RectificationForm = (props: Props) => {
               )}
             />
 
-            <div
-              className={`rectification-form-user-details ${
-                movedCarFormSelected ? 'small' : ''
-              }`}>
-              <TextInput
-                required
-                id="fullName"
-                readOnly
-                label={t('common:name')}
-                defaultValue={user?.name as string}
-              />
-              <IconCheckCircle
-                className="rectification-form-checkmark"
-                aria-label={t('common:fetched-from-profile-aria')}
-              />
-              <TextInput
-                required
-                id="ssn"
-                readOnly
-                label={t('common:ssn')}
-                defaultValue="123456-789A"
-              />
-              <IconCheckCircle
-                className="rectification-form-checkmark"
-                aria-label={t('common:fetched-from-profile-aria')}
-              />
-              <TextInput
-                required
-                id="email"
-                readOnly
-                label={t('common:email')}
-                defaultValue={user?.email as string}
-              />
-              <IconCheckCircle
-                className="rectification-form-checkmark"
-                aria-label={t('common:fetched-from-profile-aria')}
-              />
+            <div className="rectification-form-user-details">
+              <div>
+                <FieldLabel text={t('common:name')} required={true} />
+                <IconCheckCircle
+                  aria-label={t('common:fetched-from-profile-aria')}
+                  color={'var(--color-info)'}
+                />
+              </div>
+              <p>{user?.name as string}</p>
+              <div>
+                <FieldLabel text={t('common:ssn')} required={true} />
+                <IconCheckCircle
+                  aria-label={t('common:fetched-from-profile-aria')}
+                  color={'var(--color-info)'}
+                />
+              </div>
+              <p>123456-789A</p>
+              <div>
+                <FieldLabel text={t('common:email')} required={true} />
+                <IconCheckCircle
+                  aria-label={t('common:fetched-from-profile-aria')}
+                  color={'var(--color-info)'}
+                />
+              </div>
+              <p>{user?.email as string}</p>
             </div>
           </div>
 
@@ -158,7 +146,7 @@ const RectificationForm = (props: Props) => {
         </div>
         <hr />
         <div className="rectification-link-to-profile">
-          <IconCheckCircle aria-hidden="true" />
+          <IconCheckCircle aria-hidden="true" color={'var(--color-info)'} />
 
           <span>{t('common:fetched-from-profile')}</span>
           <Link

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -75,7 +75,7 @@ const RectificationForm = (props: Props) => {
               control={props.control}
               rules={{ required: t('common:required-field') as string }}
               render={({ field, fieldState }) => (
-                <div>
+                <div className="radio-group-section">
                   <FieldLabel
                     text={t(`rectificationForm:relation-info:relation`)}
                     required={true}
@@ -331,7 +331,7 @@ const RectificationForm = (props: Props) => {
             control={props.control}
             rules={{ required: t('common:required-field') as string }}
             render={({ field, fieldState }) => (
-              <div className="rectification-delivery-decision">
+              <div className="rectification-delivery-decision radio-group-section">
                 <FieldLabel
                   text={t(`rectificationForm:relation-info:relation`)}
                   required={true}

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -12,7 +12,9 @@ exports[`Component in moved car form matches snapshot 1`] = `
       <div
         class="rectification-user-section"
       >
-        <div>
+        <div
+          class="radio-group-section"
+        >
           <legend
             class="field-label"
           >
@@ -809,7 +811,7 @@ exports[`Component in moved car form matches snapshot 1`] = `
         tabindex="-1"
       />
       <div
-        class="rectification-delivery-decision"
+        class="rectification-delivery-decision radio-group-section"
       >
         <legend
           class="field-label"
@@ -875,7 +877,9 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
       <div
         class="rectification-user-section"
       >
-        <div>
+        <div
+          class="radio-group-section"
+        >
           <legend
             class="field-label"
           >
@@ -1688,7 +1692,7 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
         tabindex="-1"
       />
       <div
-        class="rectification-delivery-decision"
+        class="rectification-delivery-decision radio-group-section"
       >
         <legend
           class="field-label"

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -61,155 +61,115 @@ exports[`Component in moved car form matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="rectification-form-user-details small"
+          class="rectification-form-user-details"
         >
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="fullName"
+          <div>
+            <legend
+              class="field-label"
             >
               Nimi
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="fullName"
-                readonly=""
-                required=""
-                type="text"
-                value=""
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="ssn"
+          <p />
+          <div>
+            <legend
+              class="field-label"
             >
               Henkilötunnus
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="ssn"
-                readonly=""
-                required=""
-                type="text"
-                value="123456-789A"
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="email"
+          <p>
+            123456-789A
+          </p>
+          <div>
+            <legend
+              class="field-label"
             >
               Sähköpostiosoite
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="email"
-                readonly=""
-                required=""
-                type="text"
-                value=""
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
+          <p />
         </div>
       </div>
       <div
@@ -347,6 +307,7 @@ exports[`Component in moved car form matches snapshot 1`] = `
       <svg
         aria-hidden="true"
         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        color="var(--color-info)"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -979,155 +940,115 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="rectification-form-user-details "
+          class="rectification-form-user-details"
         >
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="fullName"
+          <div>
+            <legend
+              class="field-label"
             >
               Nimi
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="fullName"
-                readonly=""
-                required=""
-                type="text"
-                value=""
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="ssn"
+          <p />
+          <div>
+            <legend
+              class="field-label"
             >
               Henkilötunnus
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="ssn"
-                readonly=""
-                required=""
-                type="text"
-                value="123456-789A"
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
-          <div
-            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-          >
-            <label
-              class="FieldLabel-module_label__1zrXK "
-              for="email"
+          <p>
+            123456-789A
+          </p>
+          <div>
+            <legend
+              class="field-label"
             >
               Sähköpostiosoite
               <span
-                class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                class="required-icon"
               >
-                 
                 *
               </span>
-            </label>
-            <div
-              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            </legend>
+            <svg
+              aria-label="Tieto haettu Helsinki-profiilista"
+              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+              color="var(--color-info)"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <input
-                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-                id="email"
-                readonly=""
-                required=""
-                type="text"
-                value=""
-              />
-            </div>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <rect
+                  height="24"
+                  width="24"
+                />
+                <path
+                  d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
+                  fill="currentColor"
+                />
+              </g>
+            </svg>
           </div>
-          <svg
-            aria-label="Tieto haettu Helsinki-profiilista"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik rectification-form-checkmark"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <rect
-                height="24"
-                width="24"
-              />
-              <path
-                d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z"
-                fill="currentColor"
-              />
-            </g>
-          </svg>
+          <p />
         </div>
       </div>
       <div
@@ -1265,6 +1186,7 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
       <svg
         aria-hidden="true"
         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        color="var(--color-info)"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
This PR:
* Fixes the bug/feature caused by TextInput which resulted in longer text (e.g. email) to not be fully visible on RectificationForm
* Changes the color of IconCheckCircle to match the design

If any of the user info fields is too long to fit on the screen and without breaks, it breaks and wraps on new line:
![Screenshot 2023-01-27 at 10 43 46](https://user-images.githubusercontent.com/36920208/215044491-d7102403-d570-41c4-b366-7dd58775621a.png)
