### PR TITLE
Get user info from useUserProfile hook

### DIFF
--- a/src/client/WithAuth.tsx
+++ b/src/client/WithAuth.tsx
@@ -14,6 +14,7 @@ const WithAuth = (
   if (InitializingContent && !client.isInitialized()) {
     return <InitializingContent />;
   }
+  // FIXME: this shouldn't be true if apiAccessToken is expired
   return client.isAuthenticated() ? (
     <AuthorizedContent client={client} />
   ) : (

--- a/src/components/extendDueDate/ExtendDueDate.test.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { axe } from 'jest-axe';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../../utils/i18n';
@@ -11,6 +12,10 @@ import store from '../../store';
 import '@testing-library/jest-dom';
 import { t } from 'i18next';
 import { formatDate, formatISODate, getNewDueDate } from '../../utils/helpers';
+import { ClientContext } from '../../client/ClientProvider';
+
+// ClientContext needs to be added here since the tests don't get it from FormStepper
+renderHook(() => useContext(ClientContext));
 
 describe('extend due date form', () => {
   test('passes a11y validation', async () => {

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Checkbox, Link, Notification, TextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { useClient } from '../../client/hooks';
 import { formatDate, isExtensionAllowed } from '../../utils/helpers';
 import {
   selectDueDateFormValues,
   setEmailConfirmationChecked
 } from './extendDueDateFormSlice';
+import { selectUserProfile } from '../user/userSlice';
 import './ExtendDueDateForm.css';
 import {
   selectFormContent,
@@ -18,8 +18,7 @@ import Barcode from '../barcode/Barcode';
 const ExtendDueDateForm = (): React.ReactElement => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const { getUser } = useClient();
-  const user = getUser();
+  const user = useSelector(selectUserProfile);
   const formContent = useSelector(selectFormContent);
   const dueDateFormValues = useSelector(selectDueDateFormValues);
   const dueDate = formatDate(dueDateFormValues.dueDate);

--- a/src/components/formContent/FormContent.test.tsx
+++ b/src/components/formContent/FormContent.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
@@ -7,8 +7,13 @@ import { axe } from 'jest-axe';
 import FormContent from './FormContent';
 import { RectificationFormType } from './formContentSlice';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { ClientContext } from '../../client/ClientProvider';
 import store from '../../store';
 import '@testing-library/jest-dom';
+
+// ClientContext needs to be added here since the tests don't get it from FormStepper
+renderHook(() => useContext(ClientContext));
+
 const extendDueDateFormSliceMock = createSlice({
   name: 'extendDueDateForm',
   initialState: {

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import {
@@ -12,6 +12,7 @@ import {
   Stepper
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { ClientContext } from '../../client/ClientProvider';
 import { formatDate } from '../../utils/helpers';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import useUserProfile from '../../hooks/useUserProfile';
@@ -57,6 +58,8 @@ const useRectificationForm = () => {
 };
 
 const FormStepper = (props: Props): React.ReactElement => {
+  // ClientContext is needed to get user profile
+  useContext(ClientContext);
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { activeStepIndex, steps } = useSelector(selectStepperState);

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { formatDate } from '../../utils/helpers';
 import useMobileWidth from '../../hooks/useMobileWidth';
+import useUserProfile from '../../hooks/useUserProfile';
 import FormContent from '../formContent/FormContent';
 import {
   completeStep,
@@ -30,6 +31,7 @@ import {
   RectificationFormType
 } from '../formContent/formContentSlice';
 import { selectDueDateFormValues } from '../extendDueDate/extendDueDateFormSlice';
+import { setUserProfile } from '../user/userSlice';
 import './FormStepper.css';
 
 interface Props {
@@ -63,6 +65,7 @@ const FormStepper = (props: Props): React.ReactElement => {
   const lastStep = activeStepIndex === steps.length - 1;
   const [showSubmitNotification, setShowSubmitNotification] = useState(false);
   const mainPageButtonRef = useRef<null | HTMLDivElement>(null);
+  const userProfile = useUserProfile();
 
   const { control, handleSubmit } = useRectificationForm();
 
@@ -79,6 +82,12 @@ const FormStepper = (props: Props): React.ReactElement => {
   const handlePrint = () => {
     window.print();
   };
+
+  // if user profile is found, add it to redux
+  useEffect(() => {
+    userProfile && dispatch(setUserProfile(userProfile));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userProfile]);
 
   useEffect(() => {
     dispatch(setSteps(props.initialSteps));

--- a/src/components/rectificationForm/RectificationForm.test.tsx
+++ b/src/components/rectificationForm/RectificationForm.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import RectificationForm from './RectificationForm';
 import { RectificationFormType } from '../formContent/formContentSlice';
@@ -7,7 +7,10 @@ import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { axe } from 'jest-axe';
 import { renderHook } from '@testing-library/react-hooks';
 import { useForm } from 'react-hook-form';
+import { ClientContext } from '../../client/ClientProvider';
 
+// ClientContext needs to be added here since the tests don't get it from FormStepper
+renderHook(() => useContext(ClientContext));
 const { result } = renderHook(() => useForm<RectificationFormType>());
 const control = result.current.control;
 
@@ -22,9 +25,20 @@ describe('Component in parking fine appeal form', () => {
     reducers: {}
   });
 
+  const userProfileSliceMock = createSlice({
+    name: 'userProfile',
+    initialState: {
+      name: 'Test User',
+      email: 'test.user@test.fi',
+      SSN: '123456-789A'
+    },
+    reducers: {}
+  });
+
   const store = configureStore({
     reducer: {
-      formContent: formContentSliceMock.reducer
+      formContent: formContentSliceMock.reducer,
+      userProfile: userProfileSliceMock.reducer
     }
   });
 
@@ -60,9 +74,20 @@ describe('Component in moved car form', () => {
     reducers: {}
   });
 
+  const userProfileSliceMock = createSlice({
+    name: 'userProfile',
+    initialState: {
+      name: 'Test User',
+      email: 'test.user@test.fi',
+      SSN: '123456-789A'
+    },
+    reducers: {}
+  });
+
   const store = configureStore({
     reducer: {
-      formContent: formContentSliceMock.reducer
+      formContent: formContentSliceMock.reducer,
+      userProfile: userProfileSliceMock.reducer
     }
   });
 

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -14,7 +14,6 @@ import {
   TextArea,
   TextInput
 } from 'hds-react';
-import { useClient } from '../../client/hooks';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import {
   FileItem,
@@ -22,6 +21,7 @@ import {
   selectFormContent,
   RectificationControlType
 } from '../formContent/formContentSlice';
+import { selectUserProfile } from '../user/userSlice';
 import FieldLabel from '../fieldLabel/FieldLabel';
 import ErrorLabel from '../errorLabel/ErrorLabel';
 import './RectificationForm.css';
@@ -34,8 +34,7 @@ interface Props {
 
 const RectificationForm = (props: Props) => {
   const { t, i18n } = useTranslation();
-  const { getUser } = useClient();
-  const user = getUser();
+  const userProfile = useSelector(selectUserProfile);
   const selectedForm = useSelector(selectFormContent).selectedForm;
   const movedCarFormSelected = selectedForm === FormId.MOVEDCAR;
   const isMobileWidth = useMobileWidth();
@@ -107,7 +106,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>{user?.name as string}</p>
+              <p>{userProfile?.name}</p>
               <div>
                 <FieldLabel text={t('common:ssn')} required={true} />
                 <IconCheckCircle
@@ -115,7 +114,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>123456-789A</p>
+              <p>{userProfile?.SSN}</p>
               <div>
                 <FieldLabel text={t('common:email')} required={true} />
                 <IconCheckCircle
@@ -123,7 +122,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>{user?.email as string}</p>
+              <p>{userProfile?.email}</p>
             </div>
           </div>
 

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -34,7 +34,7 @@ interface Props {
 
 const RectificationForm = (props: Props) => {
   const { t, i18n } = useTranslation();
-  const userProfile = useSelector(selectUserProfile);
+  const user = useSelector(selectUserProfile);
   const selectedForm = useSelector(selectFormContent).selectedForm;
   const movedCarFormSelected = selectedForm === FormId.MOVEDCAR;
   const isMobileWidth = useMobileWidth();
@@ -106,7 +106,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>{userProfile?.name}</p>
+              <p>{user?.name}</p>
               <div>
                 <FieldLabel text={t('common:ssn')} required={true} />
                 <IconCheckCircle
@@ -114,7 +114,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>{userProfile?.SSN}</p>
+              <p>{user?.SSN}</p>
               <div>
                 <FieldLabel text={t('common:email')} required={true} />
                 <IconCheckCircle
@@ -122,7 +122,7 @@ const RectificationForm = (props: Props) => {
                   color={'var(--color-info)'}
                 />
               </div>
-              <p>{userProfile?.email}</p>
+              <p>{user?.email}</p>
             </div>
           </div>
 

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -99,7 +99,9 @@ exports[`Component in moved car form matches snapshot 1`] = `
               </g>
             </svg>
           </div>
-          <p />
+          <p>
+            Test User
+          </p>
           <div>
             <legend
               class="field-label"
@@ -171,7 +173,9 @@ exports[`Component in moved car form matches snapshot 1`] = `
               </g>
             </svg>
           </div>
-          <p />
+          <p>
+            test.user@test.fi
+          </p>
         </div>
       </div>
       <div
@@ -533,8 +537,8 @@ exports[`Component in moved car form matches snapshot 1`] = `
         >
           <label
             class="FieldLabel-module_label__1zrXK "
-            for="hds-select-8-toggle-button"
-            id="hds-select-8-label"
+            for="hds-select-7-toggle-button"
+            id="hds-select-7-label"
           >
             Maakoodi
             <span
@@ -550,10 +554,10 @@ exports[`Component in moved car form matches snapshot 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
-              aria-owns="hds-select-8-menu"
+              aria-labelledby="hds-select-7-label hds-select-7-toggle-button"
+              aria-owns="hds-select-7-menu"
               class="Select-module_button__1aIsm"
-              id="hds-select-8-toggle-button"
+              id="hds-select-7-toggle-button"
               type="button"
             >
               <span
@@ -583,10 +587,10 @@ exports[`Component in moved car form matches snapshot 1`] = `
               </svg>
             </button>
             <ul
-              aria-labelledby="hds-select-8-label"
+              aria-labelledby="hds-select-7-label"
               aria-required="true"
               class="Select-module_menu__1H2aU"
-              id="hds-select-8-menu"
+              id="hds-select-7-menu"
               role="listbox"
               style="max-height: 260px;"
               tabindex="-1"
@@ -980,7 +984,9 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
               </g>
             </svg>
           </div>
-          <p />
+          <p>
+            Test User
+          </p>
           <div>
             <legend
               class="field-label"
@@ -1052,7 +1058,9 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
               </g>
             </svg>
           </div>
-          <p />
+          <p>
+            test.user@test.fi
+          </p>
         </div>
       </div>
       <div

--- a/src/components/rectificationSummary/RectificationSummary.test.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.test.tsx
@@ -38,9 +38,20 @@ describe('Component', () => {
       reducers: {}
     });
 
+    const userSliceMock = createSlice({
+      name: 'userProfile',
+      initialState: {
+        name: 'Test User',
+        email: 'test.user@test.fi',
+        SSN: '123456-789A'
+      },
+      reducers: {}
+    });
+
     const store = configureStore({
       reducer: {
-        formContent: formContentSliceMock.reducer
+        formContent: formContentSliceMock.reducer,
+        userProfile: userSliceMock.reducer
       }
     });
     const { container } = render(

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -11,7 +11,7 @@ import {
   selectFormContent,
   selectFormValues
 } from '../formContent/formContentSlice';
-import { useClient } from '../../client/hooks';
+import { selectUserProfile } from '../user/userSlice';
 import ExtendedTextField from '../extendedTextField/ExtendedTextField';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import styles from '../styles.module.css';
@@ -19,11 +19,9 @@ import './RectificationSummary.css';
 
 const RectificationSummary = () => {
   const { t } = useTranslation();
-  const { getUser } = useClient();
-  // TODO: Get SSN from Helsinki profile / Suomi.fi
-  const user = getUser();
   const selectedForm = useSelector(selectFormContent).selectedForm;
   const formValues = useSelector(selectFormValues);
+  const userProfile = useSelector(selectUserProfile);
 
   return (
     <>
@@ -39,13 +37,13 @@ const RectificationSummary = () => {
           <TextInput
             id="name"
             label={t('common:name')}
-            value={user?.name as string}
+            value={userProfile?.name}
             readOnly
           />
           <TextInput
             id="ssn"
             label={t('common:ssn')}
-            value="123456-789A"
+            value={userProfile?.SSN}
             readOnly
           />
           <TextInput
@@ -74,7 +72,7 @@ const RectificationSummary = () => {
             value={
               formValues?.newEmailAddress
                 ? formValues?.newEmailAddress
-                : (user?.email as string)
+                : userProfile?.email
             }
             readOnly
           />

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -21,7 +21,7 @@ const RectificationSummary = () => {
   const { t } = useTranslation();
   const selectedForm = useSelector(selectFormContent).selectedForm;
   const formValues = useSelector(selectFormValues);
-  const userProfile = useSelector(selectUserProfile);
+  const user = useSelector(selectUserProfile);
 
   return (
     <>
@@ -37,13 +37,13 @@ const RectificationSummary = () => {
           <TextInput
             id="name"
             label={t('common:name')}
-            value={userProfile?.name}
+            value={user?.name}
             readOnly
           />
           <TextInput
             id="ssn"
             label={t('common:ssn')}
-            value={userProfile?.SSN}
+            value={user?.SSN}
             readOnly
           />
           <TextInput
@@ -72,7 +72,7 @@ const RectificationSummary = () => {
             value={
               formValues?.newEmailAddress
                 ? formValues?.newEmailAddress
-                : userProfile?.email
+                : user?.email
             }
             readOnly
           />

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Component matches snapshot 1`] = `
             id="name"
             readonly=""
             type="text"
-            value=""
+            value="Test User"
           />
         </div>
       </div>
@@ -158,7 +158,7 @@ exports[`Component matches snapshot 1`] = `
             id="email"
             readonly=""
             type="text"
-            value=""
+            value="test.user@test.fi"
           />
         </div>
       </div>

--- a/src/components/user/userSlice.tsx
+++ b/src/components/user/userSlice.tsx
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../store';
+
+export type SliceState = {
+  name: string;
+  email: string;
+  SSN: string;
+};
+
+const initialState: SliceState = {
+  name: '',
+  email: '',
+  SSN: ''
+};
+
+export const slice = createSlice({
+  name: 'userProfile',
+  initialState,
+  reducers: {
+    setUserProfile: (state, action) => {
+      const { lastName, firstName } = action.payload;
+      const parsedUserInfo = {
+        name: `${firstName} ${lastName}`,
+        email: action.payload.primaryEmail.email,
+        SSN:
+          action.payload.verifiedPersonalInformation
+            .nationalIdentificationNumber
+      };
+      return (state = { ...state, ...parsedUserInfo });
+    }
+  }
+});
+
+// Actions
+export const { setUserProfile } = slice.actions;
+
+// Selectors
+export const selectUserProfile = (state: RootState) => state.userProfile;
+
+export default slice.reducer;

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,15 +1,20 @@
 import { getClient } from '../client/oidc-react';
 import { getProfileData, ProfileQueryResult } from '../profile/profile';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { GraphQLClientError } from '../graphql/graphqlClient';
 import { UserProfile } from '../common';
+import { ClientContext } from '../client/ClientProvider';
 
 const useUserProfile = () => {
+  // useContext needs to be called to get user profile
+  useContext(ClientContext);
   const client = getClient();
+  const user = client.getUserProfile();
   const [profile, setProfile] = useState<UserProfile | Error | undefined>(
     undefined
   );
 
+  // listen to user and fetch the profile if a user is found
   useEffect(() => {
     const fetchProfile = async () => {
       const apiAccessToken = await client.getApiAccessToken({
@@ -27,11 +32,11 @@ const useUserProfile = () => {
       }
     };
 
-    if (!profile) {
+    if (user) {
       fetchProfile();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [user]);
 
   return profile;
 };

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,13 +1,10 @@
 import { getClient } from '../client/oidc-react';
 import { getProfileData, ProfileQueryResult } from '../profile/profile';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { GraphQLClientError } from '../graphql/graphqlClient';
 import { UserProfile } from '../common';
-import { ClientContext } from '../client/ClientProvider';
 
 const useUserProfile = () => {
-  // useContext needs to be called to get user profile
-  useContext(ClientContext);
   const client = getClient();
   const user = client.getUserProfile();
   const [profile, setProfile] = useState<UserProfile | Error | undefined>(

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,19 +3,26 @@ import { Link } from 'hds-react';
 import { ClientContext } from '../client/ClientProvider';
 import LoginComponent from '../components/Login';
 import PageContent from '../components/PageContent';
-import { useClient } from '../client/hooks';
+import useUserProfile from '../hooks/useUserProfile';
+import { UserProfile } from '../common';
+import { GraphQLClientError } from '../graphql/graphqlClient';
 
 const Index = (): React.ReactElement => {
   const clientContext = useContext(ClientContext);
-  const { getUser } = useClient();
-  const user = getUser();
+  // No need to add the user to redux here, since all the links will redirect the user
+  // to a new page, thus refreshing the store. The user is re-fetched and added to redux in FormStepper.tsx
+  const userProfile = useUserProfile() as UserProfile | GraphQLClientError;
+
+  const isUser: boolean =
+    userProfile &&
+    Object.prototype.hasOwnProperty.call(userProfile, 'firstName');
 
   return (
     <PageContent>
       {!!clientContext && clientContext.client ? (
         <>
           <h1>Pysäköinnin asiointi</h1>
-          {user && (
+          {isUser && (
             <div>
               <h2>Lähetetyt oikaisuvaatimukset</h2>
               <p>Et ole lähettänyt yhtään oikaisuvaatimusta.</p>

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import formContentReducer from './components/formContent/formContentSlice';
 import formStepperReducer from './components/formStepper/formStepperSlice';
 import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
+import userReducer from './components/user/userSlice';
 
 const store = configureStore({
   reducer: {
     formContent: formContentReducer,
     formStepper: formStepperReducer,
-    extendDueDateForm: extendDueDateFormReducer
+    extendDueDateForm: extendDueDateFormReducer,
+    userProfile: userReducer
   }
 });
 


### PR DESCRIPTION
This PR:
* Changes all occurrences of user info to fetch it using the `useUserProfile` hook instead of `getUser` which didn't return all the needed info
* Saves the user info to redux store for faster usage after it's been fetched with the hook
* Changes `useUserProfile` hook to listen to `user` from `getUser` to make sure it exists before the code inside the hook is executed

TODO:
* Change the login and navigation components to either also use the hook or ensure in some other way that they return the same authentication results. Currently `getApiAccessToken` might return 401 even though `client.isAuthenticated()` is true, which results in confusing situation for the user.