### PR TITLE
Move POA file above user info on mobile

### DIFF
--- a/src/components/rectificationForm/RectificationForm.css
+++ b/src/components/rectificationForm/RectificationForm.css
@@ -5,14 +5,15 @@
 }
 
 .rectification-info-container {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 130px);
   gap: 24px;
   margin: 24px 0 24px;
 }
 
-.rectification-user-section {
-  flex: 1;
+.rectification-poa-fileinput {
+  min-width: 300px;
 }
 
 .rectification-textarea {
@@ -37,11 +38,21 @@
 }
 
 .rectification-form-user-details {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+  grid-row: 2;
+}
+
+/* 
+  sets the items inside rectification-form-user-details as inline flex and 
+  allows expanding of the checkmark icon if needed 
+*/
+.rectification-form-user-details > div {
   display: inline-flex;
   flex-direction: column;
-  margin-top: 2rem;
   min-width: 200px;
-  max-width: 400px;
+  max-width: 350px;
 }
 
 .rectification-form-user-details div {
@@ -83,6 +94,21 @@
 }
 
 @media only screen and (max-width: 768px) {
+  .rectification-info-container {
+    grid-template-columns: repeat(1, 1fr);
+    grid-template-rows: auto;
+  }
+
+  .rectification-form-user-details {
+    grid-row: 3;
+    margin-top: 0;
+  }
+
+  .rectification-poa-fileinput {
+    grid-row: 2;
+    margin-top: var(--spacing-s);
+  }
+
   .rectification-form-container {
     display: flex;
     flex-direction: column;
@@ -91,11 +117,6 @@
   .rectification-textarea {
     height: 50vh;
     margin-bottom: var(--spacing-2-xl);
-  }
-
-  .rectification-poa-fileinput {
-    flex: 1;
-    min-width: 300px;
   }
 
   .rectification-link-to-profile {
@@ -119,7 +140,6 @@
   .rectification-poa-fileinput {
     flex: 1;
     margin-top: 5px;
-    min-width: 450px;
   }
 }
 

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -96,31 +96,31 @@ const RectificationForm: FC<Props> = ({ control, values }) => {
               const relationField = field;
               return (
                 <>
-                  <div className="rectification-user-section">
-                    <div className="radio-group-section">
-                      <FieldLabel
-                        text={t(`rectificationForm:relation-info:relation`)}
-                        required={true}
-                      />
-                      <div className="radio-group-container">
-                        {relations.map(relation => (
-                          <RadioButton
-                            key={relation}
-                            label={t(
-                              `rectificationForm:relation-info:${relation}`
-                            )}
-                            id={relation}
-                            value={relation}
-                            checked={relation === field.value}
-                            onChange={e => field.onChange(e.target.value)}
-                          />
-                        ))}
-                        {fieldState.error && (
-                          <ErrorLabel text={fieldState.error.message} />
-                        )}
-                      </div>
+                  <div className="radio-group-section">
+                    <FieldLabel
+                      text={t(`rectificationForm:relation-info:relation`)}
+                      required={true}
+                    />
+                    <div className="radio-group-container">
+                      {relations.map(relation => (
+                        <RadioButton
+                          key={relation}
+                          label={t(
+                            `rectificationForm:relation-info:${relation}`
+                          )}
+                          id={relation}
+                          value={relation}
+                          checked={relation === field.value}
+                          onChange={e => field.onChange(e.target.value)}
+                        />
+                      ))}
+                      {fieldState.error && (
+                        <ErrorLabel text={fieldState.error.message} />
+                      )}
                     </div>
-                    <div className="rectification-form-user-details">
+                  </div>
+                  <div className="rectification-form-user-details">
+                    <div>
                       <div>
                         <FieldLabel text={t('common:name')} required={true} />
                         <IconCheckCircle

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -10,61 +10,59 @@ exports[`Component in moved car form matches snapshot 1`] = `
       class="rectification-info-container"
     >
       <div
-        class="rectification-user-section"
+        class="radio-group-section"
       >
-        <div
-          class="radio-group-section"
+        <legend
+          class="field-label"
         >
-          <legend
-            class="field-label"
+          Teen oikaisuvaatimuksen
+          <span
+            class="required-icon"
           >
-            Teen oikaisuvaatimuksen
-            <span
-              class="required-icon"
-            >
-              *
-            </span>
-          </legend>
+            *
+          </span>
+        </legend>
+        <div
+          class="radio-group-container"
+        >
           <div
-            class="radio-group-container"
+            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
           >
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            <input
+              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+              id="owner"
+              type="radio"
+              value="owner"
+            />
+            <label
+              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+              for="owner"
             >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="owner"
-                type="radio"
-                value="owner"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="owner"
-              >
-                Ajoneuvon omistajana/haltijana
-              </label>
-            </div>
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              Ajoneuvon omistajana/haltijana
+            </label>
+          </div>
+          <div
+            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+          >
+            <input
+              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+              id="poa-holder"
+              type="radio"
+              value="poa-holder"
+            />
+            <label
+              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+              for="poa-holder"
             >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="poa-holder"
-                type="radio"
-                value="poa-holder"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="poa-holder"
-              >
-                Valtakirjalla (toisen puolesta)
-              </label>
-            </div>
+              Valtakirjalla (toisen puolesta)
+            </label>
           </div>
         </div>
-        <div
-          class="rectification-form-user-details"
-        >
+      </div>
+      <div
+        class="rectification-form-user-details"
+      >
+        <div>
           <div>
             <legend
               class="field-label"
@@ -808,77 +806,75 @@ exports[`Component in parking fine appeal form matches snapshot 1`] = `
       class="rectification-info-container"
     >
       <div
-        class="rectification-user-section"
+        class="radio-group-section"
       >
-        <div
-          class="radio-group-section"
+        <legend
+          class="field-label"
         >
-          <legend
-            class="field-label"
+          Teen oikaisuvaatimuksen
+          <span
+            class="required-icon"
           >
-            Teen oikaisuvaatimuksen
-            <span
-              class="required-icon"
-            >
-              *
-            </span>
-          </legend>
+            *
+          </span>
+        </legend>
+        <div
+          class="radio-group-container"
+        >
           <div
-            class="radio-group-container"
+            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
           >
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+            <input
+              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+              id="driver"
+              type="radio"
+              value="driver"
+            />
+            <label
+              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+              for="driver"
             >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="driver"
-                type="radio"
-                value="driver"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="driver"
-              >
-                Ajoneuvon kuljettajana
-              </label>
-            </div>
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              Ajoneuvon kuljettajana
+            </label>
+          </div>
+          <div
+            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+          >
+            <input
+              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+              id="owner"
+              type="radio"
+              value="owner"
+            />
+            <label
+              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+              for="owner"
             >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="owner"
-                type="radio"
-                value="owner"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="owner"
-              >
-                Ajoneuvon omistajana/haltijana
-              </label>
-            </div>
-            <div
-              class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+              Ajoneuvon omistajana/haltijana
+            </label>
+          </div>
+          <div
+            class="RadioButton-module_radioButton__1xM1I radio-button_hds-radio-button__1kktv"
+          >
+            <input
+              class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
+              id="poa-holder"
+              type="radio"
+              value="poa-holder"
+            />
+            <label
+              class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
+              for="poa-holder"
             >
-              <input
-                class="RadioButton-module_input__1cTWc radio-button_hds-radio-button__input__27sH6"
-                id="poa-holder"
-                type="radio"
-                value="poa-holder"
-              />
-              <label
-                class="RadioButton-module_label__3Zij9 radio-button_hds-radio-button__label__1XnIa"
-                for="poa-holder"
-              >
-                Valtakirjalla (toisen puolesta)
-              </label>
-            </div>
+              Valtakirjalla (toisen puolesta)
+            </label>
           </div>
         </div>
-        <div
-          class="rectification-form-user-details"
-        >
+      </div>
+      <div
+        class="rectification-form-user-details"
+      >
+        <div>
           <div>
             <legend
               class="field-label"


### PR DESCRIPTION
This PR moves the POA file from below to above user info on mobile to comply with the design. The desktop view stays the same.

![Screenshot 2023-02-13 at 12 47 30](https://user-images.githubusercontent.com/36920208/218443260-c6c8871e-38dd-407b-bf57-878c77e83821.png)


