### PR TITLE
Add rectification details view on landing page

### DIFF
--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Checkbox, Link, Notification, TextInput } from 'hds-react';
@@ -51,7 +52,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
           }
           type={extensionAllowed ? 'success' : 'error'}
           dismissible
-          closeButtonLabelText="Close notification"
+          closeButtonLabelText={t('common:close-notification') as string}
           onClose={() => setInfoNotificationOpen(false)}>
           {t('due-date:notifications:allowed:text')}
         </Notification>

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -213,7 +213,7 @@ const FormStepper = (props: Props): React.ReactElement => {
               type={'success'}
               autoClose
               dismissible
-              closeButtonLabelText="Close notification"
+              closeButtonLabelText={t('common:close-notification')}
               onClose={() => setShowSubmitNotification(false)}>
               {t(`${formContent.selectedForm}:notifications:success:text`, {
                 newDueDate: formatDate(dueDateFormValues.newDueDate)

--- a/src/components/landingPage/LandingPage.test.tsx
+++ b/src/components/landingPage/LandingPage.test.tsx
@@ -141,7 +141,7 @@ describe('landing page', () => {
     expect(sortButton).toHaveTextContent(t('landing-page:oldest-first'));
     expect(rectificationList.length).toBe(5);
     expect(rectificationList[0]).toHaveTextContent(
-      /Viimeksi muokattu 20.11.2022/
+      /Viimeksi muokattu 20.11.2021/
     );
   });
 
@@ -174,22 +174,22 @@ describe('landing page', () => {
     expect(filterButton).toBeVisible();
     fireEvent.click(filterButton);
 
-    // Filter by 'received' status
+    // Filter by 'sent' status
     const receivedOption = screen.getAllByText(
-      t('landing-page:list:status:received:default') as string
+      t('landing-page:list:status:sent:default') as string
     )[0];
     fireEvent.click(receivedOption);
 
     expect(rectificationList.length).toBe(1);
     expect(rectificationList[0]).toHaveTextContent(
-      t('landing-page:list:status:received:default')
+      t('landing-page:list:status:sent:default')
     );
     expect(rectificationCounter).toHaveTextContent(
-      `1 ${t('landing-page:list:status:received:conjugated')}`
+      `1 ${t('landing-page:list:status:sent:conjugated')}`
     );
 
     const receivedFilterButton = screen.getByRole('button', {
-      name: t('landing-page:list:status:received:default')
+      name: t('landing-page:list:status:sent:default')
     });
     fireEvent.click(receivedFilterButton);
 

--- a/src/components/landingPage/LandingPage.tsx
+++ b/src/components/landingPage/LandingPage.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, MouseEvent } from 'react';
 import { Button, IconSort, Linkbox, Pagination, Select } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { sortByDate } from '../../utils/helpers';
 import RectificationListRow from '../rectificationListRow/RectificationListRow';
 import mockRectificationList from '../../mocks/mockRectificationList'; /* use mock data for now */
 import './LandingPage.css';
@@ -47,11 +48,6 @@ const LandingPage = (): React.ReactElement => {
     setPageIndex(index);
     titleRef.current?.scrollIntoView();
   };
-
-  const sortByDate = (a: string, b: string) =>
-    sortByNewest
-      ? Date.parse(b) - Date.parse(a)
-      : Date.parse(a) - Date.parse(b);
 
   return (
     <>
@@ -104,7 +100,7 @@ const LandingPage = (): React.ReactElement => {
       <div className="rectification-list">
         <hr />
         {filteredRectifications
-          .sort((a, b) => sortByDate(a.edited, b.edited))
+          .sort((a, b) => sortByDate(a.edited, b.edited, sortByNewest))
           .slice(
             pageIndex * elementsOnPage,
             pageIndex * elementsOnPage + elementsOnPage

--- a/src/components/rectificationListDetails/RectificationListDetails.css
+++ b/src/components/rectificationListDetails/RectificationListDetails.css
@@ -1,0 +1,65 @@
+.rectification-details {
+  display: grid;
+  grid-template-columns: repeat(15, 1fr);
+  gap: var(--spacing-m) var(--spacing-s);
+  margin: var(--spacing-s) 0;
+}
+
+.rectification-details-log {
+  grid-column: 1 / 8;
+  grid-row: 1;
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.rectification-details-events,
+.rectification-details-attachments {
+  flex: 1;
+  min-width: 200px;
+}
+
+.rectification-details-title {
+  font-weight: 500 !important;
+  font-size: 18px !important;
+}
+
+.rectification-details-events p,
+.rectification-details-attachments p {
+  font-size: 16px;
+  margin: var(--spacing-xs) 0;
+}
+
+.rectification-details-attachments p {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rectification-details-button-container {
+  grid-column: 8 / 16;
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  max-width: 400px;
+  min-width: 200px;
+}
+
+@media (max-width: 768px) {
+  .rectification-details-button-container {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 992px) {
+  .rectification-details-button-container {
+    grid-column: 1 / 16;
+    grid-row: 1;
+  }
+
+  .rectification-details-log {
+    grid-column: 1 / 16;
+    grid-row: 2;
+    flex-direction: column-reverse;
+  }
+}

--- a/src/components/rectificationListDetails/RectificationListDetails.tsx
+++ b/src/components/rectificationListDetails/RectificationListDetails.tsx
@@ -30,14 +30,16 @@ const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
               </p>
             ))}
         </div>
-        <div className="rectification-details-attachments">
-          <span className="rectification-details-title">
-            {t('landing-page:list:details:attachments')}
-          </span>
-          {form.attachments.map((attachment, i) => (
-            <p key={i}>{attachment.name}</p>
-          ))}
-        </div>
+        {form.type !== 'due-date' && (
+          <div className="rectification-details-attachments">
+            <span className="rectification-details-title">
+              {t('landing-page:list:details:attachments')}
+            </span>
+            {form.attachments.map((attachment, i) => (
+              <p key={i}>{attachment.name}</p>
+            ))}
+          </div>
+        )}
       </div>
       {form.type === 'due-date' ? (
         <div className="rectification-details-button-container">

--- a/src/components/rectificationListDetails/RectificationListDetails.tsx
+++ b/src/components/rectificationListDetails/RectificationListDetails.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react';
-import { Button, IconArrowRight, IconDocument } from 'hds-react';
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+import React, { FC, useState } from 'react';
+import { Button, IconArrowRight, IconDocument, Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { RectificationListItem } from '../rectificationListRow/rectificationListRowSlice';
-import { formatDateTime, sortByDate } from '../../utils/helpers';
+import { formatDate, formatDateTime, sortByDate } from '../../utils/helpers';
 import './RectificationListDetails.css';
 
 interface Props {
@@ -10,6 +11,9 @@ interface Props {
 }
 const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
   const { t } = useTranslation();
+  const [dueDateNotificationOpen, setDueDateNotificationOpen] = useState(true);
+  const [mailedNotificationOpen, setMailedNotificationOpen] = useState(true);
+
   return (
     <div className="rectification-details">
       <div className="rectification-details-log">
@@ -35,14 +39,45 @@ const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
           ))}
         </div>
       </div>
-      <div className="rectification-details-button-container">
-        <Button iconRight={<IconDocument />}>
-          {t('landing-page:list:details:open-decision')}
-        </Button>
-        <Button variant="secondary" iconRight={<IconArrowRight />}>
-          {t('landing-page:list:details:show-form')}
-        </Button>
-      </div>
+      {form.type === 'due-date' ? (
+        <div className="rectification-details-button-container">
+          {dueDateNotificationOpen && (
+            <Notification
+              size="small"
+              label={t('landing-page:list:details:due-date-notification:label')}
+              dismissible
+              closeButtonLabelText={t('common:close-notification') as string}
+              onClose={() => setDueDateNotificationOpen(false)}>
+              {t(`landing-page:list:details:due-date-notification:text`, {
+                newDueDate: formatDate(
+                  '2022-01-02T13:20:00Z'
+                ) /* TODO: Get the real date */
+              })}
+            </Notification>
+          )}
+        </div>
+      ) : (
+        <div className="rectification-details-button-container">
+          {form.status === 'solved-online' && (
+            <Button iconRight={<IconDocument />}>
+              {t('landing-page:list:details:open-decision')}
+            </Button>
+          )}
+          {form.status === 'solved-mailed' && mailedNotificationOpen && (
+            <Notification
+              size="small"
+              label={t('landing-page:list:details:mailed-notification:label')}
+              dismissible
+              closeButtonLabelText={t('common:close-notification') as string}
+              onClose={() => setMailedNotificationOpen(false)}>
+              {t('landing-page:list:details:mailed-notification:text')}
+            </Notification>
+          )}
+          <Button variant="secondary" iconRight={<IconArrowRight />}>
+            {t('landing-page:list:details:show-form')}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/rectificationListDetails/RectificationListDetails.tsx
+++ b/src/components/rectificationListDetails/RectificationListDetails.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react';
+import { Button, IconArrowRight, IconDocument } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { RectificationListItem } from '../rectificationListRow/rectificationListRowSlice';
+import { formatDateTime, sortByDate } from '../../utils/helpers';
+import './RectificationListDetails.css';
+
+interface Props {
+  form: RectificationListItem;
+}
+const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
+  const { t } = useTranslation();
+  return (
+    <div className="rectification-details">
+      <div className="rectification-details-log">
+        <div className="rectification-details-events">
+          <span className="rectification-details-title">
+            {t('landing-page:list:details:events')}
+          </span>
+          {form.events
+            .sort((a, b) => sortByDate(a.timestamp, b.timestamp, true))
+            .map((event, i) => (
+              <p key={i}>
+                {formatDateTime(event.timestamp)}{' '}
+                {t(`landing-page:list:status:${event.status}:default`)}
+              </p>
+            ))}
+        </div>
+        <div className="rectification-details-attachments">
+          <span className="rectification-details-title">
+            {t('landing-page:list:details:attachments')}
+          </span>
+          {form.attachments.map((attachment, i) => (
+            <p key={i}>{attachment.name}</p>
+          ))}
+        </div>
+      </div>
+      <div className="rectification-details-button-container">
+        <Button iconRight={<IconDocument />}>
+          {t('landing-page:list:details:open-decision')}
+        </Button>
+        <Button variant="secondary" iconRight={<IconArrowRight />}>
+          {t('landing-page:list:details:show-form')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RectificationListDetails;

--- a/src/components/rectificationListDetails/RectificationListDetails.tsx
+++ b/src/components/rectificationListDetails/RectificationListDetails.tsx
@@ -9,10 +9,14 @@ import './RectificationListDetails.css';
 interface Props {
   form: RectificationListItem;
 }
+
 const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
   const { t } = useTranslation();
-  const [dueDateNotificationOpen, setDueDateNotificationOpen] = useState(true);
-  const [mailedNotificationOpen, setMailedNotificationOpen] = useState(true);
+  const isDueDateForm = form.type === 'due-date';
+  const notificationType = isDueDateForm ? form.type : form.status;
+  const [notificationOpen, setNotificationOpen] = useState(
+    isDueDateForm || form.status === 'solved-mailed'
+  );
 
   return (
     <div className="rectification-details">
@@ -30,7 +34,7 @@ const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
               </p>
             ))}
         </div>
-        {form.type !== 'due-date' && (
+        {!isDueDateForm && (
           <div className="rectification-details-attachments">
             <span className="rectification-details-title">
               {t('landing-page:list:details:attachments')}
@@ -41,45 +45,37 @@ const RectificationListDetails: FC<Props> = ({ form }): React.ReactElement => {
           </div>
         )}
       </div>
-      {form.type === 'due-date' ? (
-        <div className="rectification-details-button-container">
-          {dueDateNotificationOpen && (
-            <Notification
-              size="small"
-              label={t('landing-page:list:details:due-date-notification:label')}
-              dismissible
-              closeButtonLabelText={t('common:close-notification') as string}
-              onClose={() => setDueDateNotificationOpen(false)}>
-              {t(`landing-page:list:details:due-date-notification:text`, {
-                newDueDate: formatDate(
+      <div className="rectification-details-button-container">
+        {notificationOpen && (
+          <Notification
+            size="small"
+            label={t(
+              `landing-page:list:details:notification:${notificationType}:label`
+            )}
+            dismissible
+            closeButtonLabelText={t('common:close-notification') as string}
+            onClose={() => setNotificationOpen(false)}>
+            {t(
+              `landing-page:list:details:notification:${notificationType}:text`,
+              {
+                timestamp: formatDate(
                   '2022-01-02T13:20:00Z'
                 ) /* TODO: Get the real date */
-              })}
-            </Notification>
-          )}
-        </div>
-      ) : (
-        <div className="rectification-details-button-container">
-          {form.status === 'solved-online' && (
-            <Button iconRight={<IconDocument />}>
-              {t('landing-page:list:details:open-decision')}
-            </Button>
-          )}
-          {form.status === 'solved-mailed' && mailedNotificationOpen && (
-            <Notification
-              size="small"
-              label={t('landing-page:list:details:mailed-notification:label')}
-              dismissible
-              closeButtonLabelText={t('common:close-notification') as string}
-              onClose={() => setMailedNotificationOpen(false)}>
-              {t('landing-page:list:details:mailed-notification:text')}
-            </Notification>
-          )}
+              }
+            )}
+          </Notification>
+        )}
+        {form.status === 'solved-online' && (
+          <Button iconRight={<IconDocument />}>
+            {t('landing-page:list:details:open-decision')}
+          </Button>
+        )}
+        {!isDueDateForm && (
           <Button variant="secondary" iconRight={<IconArrowRight />}>
             {t('landing-page:list:details:show-form')}
           </Button>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/rectificationListRow/RectificationListRow.css
+++ b/src/components/rectificationListRow/RectificationListRow.css
@@ -19,7 +19,7 @@
   grid-row: 1;
   display: flex;
   align-items: center;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 20px;
   color: var(--color-black-60);
 }

--- a/src/components/rectificationListRow/RectificationListRow.css
+++ b/src/components/rectificationListRow/RectificationListRow.css
@@ -32,7 +32,7 @@
 }
 
 .rectification-list-row-button {
-  grid-column: 13 / 16;
+  grid-column: 12 / 16;
   grid-row: 2;
   display: flex;
   justify-self: flex-end;

--- a/src/components/rectificationListRow/RectificationListRow.test.tsx
+++ b/src/components/rectificationListRow/RectificationListRow.test.tsx
@@ -1,0 +1,266 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../utils/i18n';
+import RectificationListRow from './RectificationListRow';
+import mockRectificationList from '../../mocks/mockRectificationList';
+import { Provider } from 'react-redux';
+import store from '../../store';
+import '@testing-library/jest-dom';
+import { t } from 'i18next';
+
+describe('rectification list row', () => {
+  test('passes a11y validation', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <RectificationListRow form={mockRectificationList[0]} />
+      </Provider>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  describe('renders', () => {
+    test('solved (mailed) rectification form details correctly', async () => {
+      const { container } = render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <RectificationListRow form={mockRectificationList[0]} />
+          </I18nextProvider>
+        </Provider>
+      );
+
+      const status = container.getElementsByClassName(
+        'rectification-list-row-status'
+      )[0];
+      expect(status).toHaveTextContent(
+        t('landing-page:list:status:solved-mailed:default')
+      );
+
+      const showMoreButton = screen.getByRole('button', {
+        name: t('landing-page:list:show-more')
+      });
+      expect(showMoreButton).toBeVisible();
+
+      // Details not visible before 'show more' button is clicked
+      const details = container.getElementsByClassName('rectification-details');
+      expect(details.length).toBe(0);
+
+      const events = container.getElementsByClassName(
+        'rectification-details-events'
+      );
+      expect(events.length).toBe(0);
+
+      const attachments = container.getElementsByClassName(
+        'rectification-details-attachments'
+      );
+      expect(attachments.length).toBe(0);
+
+      fireEvent.click(showMoreButton);
+
+      // Details visible and contain right content
+      expect(details.length).toBe(1);
+
+      // Events
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:sent:default')
+      );
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:processing:default')
+      );
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:received:default')
+      );
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:solved-mailed:default')
+      );
+
+      // Attachments
+      expect(attachments.length).toBe(1);
+      expect(attachments[0]).toHaveTextContent(
+        'long-file-name-for-testing-abcd-efgh-ijkl.png'
+      );
+      expect(attachments[0]).toHaveTextContent('test-image2.jpg');
+      expect(attachments[0]).toHaveTextContent('test-file1.pdf');
+
+      // Notification
+      const mailNotification = screen.getByRole('region', {
+        name: 'Notification'
+      });
+      expect(mailNotification).toBeVisible();
+      expect(mailNotification).toHaveTextContent(
+        t('landing-page:list:details:mailed-notification:text')
+      );
+
+      // 'Show form' button is visible but 'open decision' button is not
+      const showFormButton = screen.getByRole('button', {
+        name: t('landing-page:list:details:show-form')
+      });
+      expect(showFormButton).toBeVisible();
+
+      const openDecisionButton = screen.queryByRole('button', {
+        name: t('landing-page:list:details:open-decision')
+      });
+      expect(openDecisionButton).not.toBeInTheDocument();
+    });
+
+    test('solved (online) rectification form details correctly', async () => {
+      render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <RectificationListRow form={mockRectificationList[4]} />
+          </I18nextProvider>
+        </Provider>
+      );
+
+      const showMoreButton = screen.getByRole('button', {
+        name: t('landing-page:list:show-more')
+      });
+      expect(showMoreButton).toBeVisible();
+
+      fireEvent.click(showMoreButton);
+
+      // No notifications visible
+      const notification = screen.queryByRole('region', {
+        name: 'Notification'
+      });
+      expect(notification).not.toBeInTheDocument();
+
+      // Both buttons visible
+      const showFormButton = screen.getByRole('button', {
+        name: t('landing-page:list:details:show-form')
+      });
+      expect(showFormButton).toBeVisible();
+
+      const openDecisionButton = screen.getByRole('button', {
+        name: t('landing-page:list:details:open-decision')
+      });
+      expect(openDecisionButton).toBeVisible();
+    });
+
+    test('rectification form that is being processed correctly', async () => {
+      const { container } = render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <RectificationListRow form={mockRectificationList[5]} />
+          </I18nextProvider>
+        </Provider>
+      );
+      const showMoreButton = screen.getByRole('button', {
+        name: t('landing-page:list:show-more')
+      });
+      expect(showMoreButton).toBeVisible();
+
+      fireEvent.click(showMoreButton);
+
+      // No notifications visible
+      const notification = screen.queryByRole('region', {
+        name: 'Notification'
+      });
+      expect(notification).not.toBeInTheDocument();
+
+      // 'Show form' button is visible but 'open decision' button is not
+      const showFormButton = screen.getByRole('button', {
+        name: t('landing-page:list:details:show-form')
+      });
+      expect(showFormButton).toBeVisible();
+
+      const openDecisionButton = screen.queryByRole('button', {
+        name: t('landing-page:list:details:open-decision')
+      });
+      expect(openDecisionButton).not.toBeInTheDocument();
+
+      // Events and attachments empty when there is no data
+      const events = container.getElementsByClassName(
+        'rectification-details-events'
+      );
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:details:events')
+      );
+
+      const attachments = container.getElementsByClassName(
+        'rectification-details-attachments'
+      );
+      expect(attachments.length).toBe(1);
+      expect(attachments[0]).toHaveTextContent(
+        t('landing-page:list:details:attachments')
+      );
+    });
+
+    test('due date form details correctly', async () => {
+      const { container } = render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <RectificationListRow form={mockRectificationList[6]} />
+          </I18nextProvider>
+        </Provider>
+      );
+
+      const status = container.getElementsByClassName(
+        'rectification-list-row-status'
+      )[0];
+      expect(status).toHaveTextContent(
+        t('landing-page:list:status:received:default')
+      );
+
+      const showMoreButton = screen.getByRole('button', {
+        name: t('landing-page:list:show-more')
+      });
+      expect(showMoreButton).toBeVisible();
+
+      // Details not visible before 'show form' button is clicked
+      const details = container.getElementsByClassName('rectification-details');
+      expect(details.length).toBe(0);
+
+      const events = container.getElementsByClassName(
+        'rectification-details-events'
+      );
+      expect(events.length).toBe(0);
+
+      const attachments = container.getElementsByClassName(
+        'rectification-details-attachments'
+      );
+      expect(attachments.length).toBe(0);
+
+      fireEvent.click(showMoreButton);
+
+      // Details visible and contain right content
+      expect(details.length).toBe(1);
+
+      // Events
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:sent:default')
+      );
+      expect(events[0]).toHaveTextContent(
+        t('landing-page:list:status:received:default')
+      );
+
+      // Attachments should be empty and title not visible
+      expect(attachments.length).toBe(0);
+
+      // Notification
+      const mailNotification = screen.getByRole('region', {
+        name: 'Notification'
+      });
+      expect(mailNotification).toBeVisible();
+      expect(mailNotification).toHaveTextContent(
+        /Eräpäivää on siirretty 30 päivällä./
+      );
+
+      // Buttons not visible
+      const showFormButton = screen.queryByRole('button', {
+        name: t('landing-page:list:details:show-form')
+      });
+      expect(showFormButton).not.toBeInTheDocument();
+
+      const openDecisionButton = screen.queryByRole('button', {
+        name: t('landing-page:list:details:open-decision')
+      });
+      expect(openDecisionButton).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/rectificationListRow/RectificationListRow.test.tsx
+++ b/src/components/rectificationListRow/RectificationListRow.test.tsx
@@ -91,7 +91,7 @@ describe('rectification list row', () => {
       });
       expect(mailNotification).toBeVisible();
       expect(mailNotification).toHaveTextContent(
-        t('landing-page:list:details:mailed-notification:text')
+        t('landing-page:list:details:notification:solved-mailed:text')
       );
 
       // 'Show form' button is visible but 'open decision' button is not

--- a/src/components/rectificationListRow/RectificationListRow.tsx
+++ b/src/components/rectificationListRow/RectificationListRow.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { Button, IconAngleDown, IconAngleUp } from 'hds-react';
 import { RectificationListItem } from './rectificationListRowSlice';
+import RectificationListDetails from '../rectificationListDetails/RectificationListDetails';
 import CustomTag from '../customTag/CustomTag';
 import { formatDateTime } from '../../utils/helpers';
 import './RectificationListRow.css';
@@ -25,31 +26,36 @@ const RectificationListRow: FC<Props> = ({ form }): React.ReactElement => {
   };
 
   return (
-    <div className="rectification-list-row">
-      <div className="rectification-list-row-date">
-        {`${t('landing-page:list:last-edited')} ${formatDateTime(form.edited)}`}
+    <>
+      <div className="rectification-list-row">
+        <div className="rectification-list-row-date">
+          {`${t('landing-page:list:last-edited')} ${formatDateTime(
+            form.edited
+          )}`}
+        </div>
+        <div className="rectification-list-row-title">
+          {`${t(`${form.type}:title`)} (${form.id})`}
+        </div>
+        <div className="rectification-list-row-status">
+          <CustomTag
+            text={t(`landing-page:list:status:${form.status}:default`)}
+            color={tagColor(form.status)}
+            textColor={form.status !== 'processing' ? 'white' : undefined}
+          />
+        </div>
+        <Button
+          className="rectification-list-row-button"
+          variant="supplementary"
+          size="small"
+          iconRight={extended ? <IconAngleUp /> : <IconAngleDown />}
+          onClick={() => setExtended(!extended)}>
+          {extended
+            ? t('landing-page:list:show-less')
+            : t('landing-page:list:show-more')}
+        </Button>
       </div>
-      <div className="rectification-list-row-title">
-        {`${t(`${form.type}:title`)} (${form.id})`}
-      </div>
-      <div className="rectification-list-row-status">
-        <CustomTag
-          text={t(`landing-page:list:status:${form.status}:default`)}
-          color={tagColor(form.status)}
-          textColor={form.status !== 'processing' ? 'white' : undefined}
-        />
-      </div>
-      <Button
-        className="rectification-list-row-button"
-        variant="supplementary"
-        size="small"
-        iconRight={extended ? <IconAngleUp /> : <IconAngleDown />}
-        onClick={() => setExtended(!extended)}>
-        {extended
-          ? t('landing-page:list:show-less')
-          : t('landing-page:list:show-more')}
-      </Button>
-    </div>
+      {extended && <RectificationListDetails form={form} />}
+    </>
   );
 };
 

--- a/src/components/rectificationListRow/rectificationListRowSlice.tsx
+++ b/src/components/rectificationListRow/rectificationListRowSlice.tsx
@@ -1,6 +1,15 @@
+import { FileItem } from '../formContent/formContentSlice';
+
 export type RectificationListItem = {
-  id: number;
+  id: string;
   type: string;
   status: string;
   edited: string;
+  events: StatusEvent[];
+  attachments: FileItem[];
+};
+
+type StatusEvent = {
+  status: string;
+  timestamp: string;
 };

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -276,6 +276,12 @@
           "conjugated": "lähetettyä"
         }
       },
+      "details": {
+        "events": "Tapahtumat",
+        "attachments": "Liitteet",
+        "open-decision": "Avaa päätös",
+        "show-form": "Näytä oikaisuvaatimus"
+      },
       "last-edited": "Viimeksi muokattu",
       "show-more": "Näytä lisää",
       "show-less": "Näytä vähemmän",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -20,6 +20,7 @@
     "show-more": "Näytä enemmän",
     "show-less": "Näytä vähemmän",
     "characters": "merkkiä",
+    "close-notification": "Sulje ilmoitus",
     "login-prompt": {
       "title": "Sessio päättynyt",
       "body": "Olet kirjautunut ulos toisessa ikkunassa",
@@ -280,7 +281,15 @@
         "events": "Tapahtumat",
         "attachments": "Liitteet",
         "open-decision": "Avaa päätös",
-        "show-form": "Näytä oikaisuvaatimus"
+        "show-form": "Näytä oikaisuvaatimus",
+        "mailed-notification": {
+          "label": "Päätös on postitettu",
+          "text": "Päätös on postitettu sinulle kirjeitse antamaasi osoitteeseen."
+        },
+        "due-date-notification": {
+          "label": "Eräpäivää on siirretty",
+          "text": "Eräpäivää on siirretty 30 päivällä. Uusi eräpäivä on {{newDueDate}}."
+        }
       },
       "last-edited": "Viimeksi muokattu",
       "show-more": "Näytä lisää",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -282,13 +282,15 @@
         "attachments": "Liitteet",
         "open-decision": "Avaa päätös",
         "show-form": "Näytä oikaisuvaatimus",
-        "mailed-notification": {
-          "label": "Päätös on postitettu",
-          "text": "Päätös on postitettu sinulle kirjeitse antamaasi osoitteeseen."
-        },
-        "due-date-notification": {
-          "label": "Eräpäivää on siirretty",
-          "text": "Eräpäivää on siirretty 30 päivällä. Uusi eräpäivä on {{newDueDate}}."
+        "notification": {
+          "due-date": {
+            "label": "Eräpäivää on siirretty",
+            "text": "Eräpäivää on siirretty 30 päivällä. Uusi eräpäivä on {{timestamp}}."
+          },
+          "solved-mailed": {
+            "label": "Päätös on postitettu",
+            "text": "Päätös on postitettu sinulle kirjeitse antamaasi osoitteeseen."
+          }
         }
       },
       "last-edited": "Viimeksi muokattu",

--- a/src/mocks/mockRectificationList.ts
+++ b/src/mocks/mockRectificationList.ts
@@ -115,6 +115,10 @@ const mockRectificationList: RectificationListItem[] = [
       {
         status: 'sent',
         timestamp: '2023-01-30T15:39:58Z'
+      },
+      {
+        status: 'solved-online',
+        timestamp: '2023-02-01T08:39:11Z'
       }
     ],
     attachments: [
@@ -146,24 +150,16 @@ const mockRectificationList: RectificationListItem[] = [
   {
     id: '78901234',
     type: 'due-date',
-    status: 'solved-online',
-    edited: '2022-11-20:18:11:21Z',
+    status: 'received',
+    edited: '2021-11-20:18:11:21Z',
     events: [
       {
-        status: 'solved-online',
-        timestamp: '2022-11-01:18:11:21Z'
-      },
-      {
-        status: 'processing',
-        timestamp: '2022-11-30T15:40:10Z'
-      },
-      {
         status: 'received',
-        timestamp: '2021-11-30T15:40:00Z'
+        timestamp: '2021-11-20T15:40:00Z'
       },
       {
         status: 'sent',
-        timestamp: '2022-11-30T15:39:58Z'
+        timestamp: '2021-11-10T15:39:58Z'
       }
     ],
     attachments: []

--- a/src/mocks/mockRectificationList.ts
+++ b/src/mocks/mockRectificationList.ts
@@ -2,46 +2,171 @@
 import { RectificationListItem } from '../components/rectificationListRow/rectificationListRowSlice';
 const mockRectificationList: RectificationListItem[] = [
   {
-    id: 12345678,
+    id: '12345678',
     type: 'parking-fine',
     status: 'solved-mailed',
-    edited: '2022-12-01T06:00:00Z'
+    edited: '2022-12-01T06:00:00Z',
+    events: [
+      {
+        status: 'processing',
+        timestamp: '2022-11-11T07:40:00Z'
+      },
+      {
+        status: 'received',
+        timestamp: '2022-11-10T07:40:00Z'
+      },
+      {
+        status: 'sent',
+        timestamp: '2022-11-10T07:39:00Z'
+      }
+    ],
+    attachments: [
+      {
+        name: 'long-file-name-for-testing-abcd-efgh-ijkl.png',
+        size: 5600,
+        type: 'png'
+      },
+      {
+        name: 'test-image2.jpg',
+        size: 65040,
+        type: 'jpg'
+      },
+      {
+        name: 'test-file1.pdf',
+        size: 70500,
+        type: 'pdf'
+      }
+    ]
   },
   {
-    id: 23456789,
+    id: '23456789',
     type: 'parking-fine',
     status: 'received',
-    edited: '2023-02-11T21:20:00Z'
+    edited: '2023-02-11T21:20:00Z',
+    events: [
+      {
+        status: 'received',
+        timestamp: '2023-02-11T21:20:00Z'
+      },
+      {
+        status: 'sent',
+        timestamp: '2023-01-10T12:00:00Z'
+      }
+    ],
+    attachments: [
+      {
+        name: 'test-image1.png',
+        size: 5600,
+        type: 'png'
+      },
+      {
+        name: 'test-image2.jpg',
+        size: 65040,
+        type: 'jpg'
+      }
+    ]
   },
   {
-    id: 34567890,
+    id: '34567890',
     type: 'due-date',
     status: 'processing',
-    edited: '2023-02-11T14:00:20Z'
+    edited: '2023-02-11T14:00:20Z',
+    events: [
+      {
+        status: 'sent',
+        timestamp: '2023-01-20T11:11:11Z'
+      }
+    ],
+    attachments: [
+      {
+        name: 'test-image3.jpg',
+        size: 65049,
+        type: 'jpg'
+      },
+      {
+        name: 'test-file1.pdf',
+        size: 80500,
+        type: 'pdf'
+      }
+    ]
   },
   {
-    id: 45678901,
+    id: '45678901',
     type: 'moved-car',
     status: 'sent',
-    edited: '2023-02-01T21:59:59Z'
+    edited: '2023-02-01T21:59:59Z',
+    events: [],
+    attachments: []
   },
   {
-    id: 56789012,
+    id: '56789012',
     type: 'moved-car',
     status: 'solved-online',
-    edited: '2023-02-01T08:39:11Z'
+    edited: '2023-02-01T08:39:11Z',
+    events: [
+      {
+        status: 'processing',
+        timestamp: '2023-01-30T15:40:10Z'
+      },
+      {
+        status: 'received',
+        timestamp: '2023-01-30T15:40:00Z'
+      },
+      {
+        status: 'sent',
+        timestamp: '2023-01-30T15:39:58Z'
+      }
+    ],
+    attachments: [
+      {
+        name: 'test-image1.png',
+        size: 5600,
+        type: 'png'
+      },
+      {
+        name: 'test-image2.jpg',
+        size: 65040,
+        type: 'jpg'
+      },
+      {
+        name: 'test-file1.pdf',
+        size: 70500,
+        type: 'pdf'
+      }
+    ]
   },
   {
-    id: 67890123,
+    id: '67890123',
     type: 'parking-fine',
     status: 'processing',
-    edited: '2023-02-11T20:22:22Z'
+    edited: '2023-02-11T20:22:22Z',
+    events: [],
+    attachments: []
   },
   {
-    id: 78901234,
+    id: '78901234',
     type: 'due-date',
     status: 'solved-online',
-    edited: '2022-11-20:18:11:21Z'
+    edited: '2022-11-20:18:11:21Z',
+    events: [
+      {
+        status: 'solved-online',
+        timestamp: '2022-11-01:18:11:21Z'
+      },
+      {
+        status: 'processing',
+        timestamp: '2022-11-30T15:40:10Z'
+      },
+      {
+        status: 'received',
+        timestamp: '2021-11-30T15:40:00Z'
+      },
+      {
+        status: 'sent',
+        timestamp: '2022-11-30T15:39:58Z'
+      }
+    ],
+    attachments: []
   }
 ];
 

--- a/src/mocks/mockRectificationList.ts
+++ b/src/mocks/mockRectificationList.ts
@@ -77,18 +77,7 @@ const mockRectificationList: RectificationListItem[] = [
         timestamp: '2023-01-20T11:11:11Z'
       }
     ],
-    attachments: [
-      {
-        name: 'test-image3.jpg',
-        size: 65049,
-        type: 'jpg'
-      },
-      {
-        name: 'test-file1.pdf',
-        size: 80500,
-        type: 'pdf'
-      }
-    ]
+    attachments: []
   },
   {
     id: '45678901',

--- a/src/mocks/mockRectificationList.ts
+++ b/src/mocks/mockRectificationList.ts
@@ -8,6 +8,10 @@ const mockRectificationList: RectificationListItem[] = [
     edited: '2022-12-01T06:00:00Z',
     events: [
       {
+        status: 'solved-mailed',
+        timestamp: '2022-12-01T06:00:00Z'
+      },
+      {
         status: 'processing',
         timestamp: '2022-11-11T07:40:00Z'
       },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -51,3 +51,6 @@ export const formatBytes = (bytes: number): string => {
       : sizeInUnit.toFixed(1)
   } ${sizeUnits[sizeUnitIndex]}`;
 };
+
+export const sortByDate = (a: string, b: string, sortByNewest: boolean) =>
+  sortByNewest ? Date.parse(b) - Date.parse(a) : Date.parse(a) - Date.parse(b);


### PR DESCRIPTION
This PR adds the details view that is opened on rectification form list of landing page when "show more" button is clicked. 
The view contains:
* A list of status change events
* A list of attachments (except when the form type is extend due date)
  * If a file name is too long to be shown fully, it's truncated and the end is replaced with three dots "..." 
* Notifications and buttons based on the form type and form status

TODO:
* The button functionalities


<img width="972" alt="Screenshot 2023-03-01 at 15 24 37" src="https://user-images.githubusercontent.com/36920208/222151668-95500b1d-4513-4c3e-a9ce-6f48f2b74734.png">
