### PR TITLE
Fix pagination when filtering results on landing page

### DIFF
--- a/src/components/landingPage/LandingPage.test.tsx
+++ b/src/components/landingPage/LandingPage.test.tsx
@@ -102,9 +102,9 @@ describe('landing page', () => {
       // 7 results in total, 5 results shown on the main page
       expect(rectificationList.length).toBe(5);
 
-      const nextPagebutton = screen.getByTestId('hds-pagination-next-button');
-      expect(nextPagebutton).toBeVisible();
-      fireEvent.click(nextPagebutton);
+      const nextPageButton = screen.getByTestId('hds-pagination-next-button');
+      expect(nextPageButton).toBeVisible();
+      fireEvent.click(nextPageButton);
 
       // 2 results on the second page
       expect(rectificationList.length).toBe(2);

--- a/src/components/landingPage/LandingPage.test.tsx
+++ b/src/components/landingPage/LandingPage.test.tsx
@@ -112,14 +112,13 @@ describe('landing page', () => {
   });
 
   test('sorts results correctly by date', async () => {
-    const renderResult = render(
+    const { container } = render(
       <Provider store={store}>
         <I18nextProvider i18n={i18n}>
           <LandingPage />
         </I18nextProvider>
       </Provider>
     );
-    const { container } = renderResult;
 
     // Get all rectification forms
     const rectificationList = container.getElementsByClassName(
@@ -146,14 +145,13 @@ describe('landing page', () => {
   });
 
   test('filters results correctly by status', async () => {
-    const renderResult = render(
+    const { container } = render(
       <Provider store={store}>
         <I18nextProvider i18n={i18n}>
           <LandingPage />
         </I18nextProvider>
       </Provider>
     );
-    const { container } = renderResult;
 
     // Get all rectification forms
     const rectificationList = container.getElementsByClassName(
@@ -205,6 +203,51 @@ describe('landing page', () => {
     );
     expect(rectificationCounter).toHaveTextContent(
       `2 ${t('landing-page:list:status:processing:conjugated')}`
+    );
+  });
+
+  test('filters results correctly by status after page is changed', async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <I18nextProvider i18n={i18n}>
+          <LandingPage />
+        </I18nextProvider>
+      </Provider>
+    );
+
+    // Get all rectification forms
+    const rectificationList = container.getElementsByClassName(
+      'rectification-list-row'
+    );
+
+    // Click the 'next page' button
+    const nextPageButton = screen.getByTestId('hds-pagination-next-button');
+    expect(nextPageButton).toBeVisible();
+    fireEvent.click(nextPageButton);
+
+    // Filter results
+
+    // Open dropdown menu
+    const filterButton = screen.getByRole('button', {
+      name: t('landing-page:list:status:show-all:default')
+    });
+    expect(filterButton).toBeVisible();
+    fireEvent.click(filterButton);
+
+    // Filter by 'solved (mailed)' status
+    const solvedMailedOption = screen.getAllByText(
+      t('landing-page:list:status:solved-mailed:default') as string
+    )[0];
+    fireEvent.click(solvedMailedOption);
+
+    // 1 result should be shown
+    expect(rectificationList.length).toBe(1);
+
+    const rectificationCounter = container.getElementsByClassName(
+      'rectification-list-sent-count'
+    )[0];
+    expect(rectificationCounter).toHaveTextContent(
+      `1 ${t('landing-page:list:status:solved-mailed:conjugated')}`
     );
   });
 });

--- a/src/components/landingPage/LandingPage.tsx
+++ b/src/components/landingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, MouseEvent } from 'react';
+import React, { useRef, useState } from 'react';
 import { Button, IconSort, Linkbox, Pagination, Select } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { sortByDate } from '../../utils/helpers';
@@ -32,8 +32,8 @@ const LandingPage = (): React.ReactElement => {
   ];
   const statuses = [
     'show-all',
-    'received',
     'sent',
+    'received',
     'processing',
     'solved-online',
     'solved-mailed'
@@ -43,8 +43,7 @@ const LandingPage = (): React.ReactElement => {
     label: t(`landing-page:list:status:${status}:default`)
   }));
 
-  const handlePageChange = (event: MouseEvent, index: number) => {
-    event.preventDefault();
+  const handlePageChange = (index: number) => {
     setPageIndex(index);
     titleRef.current?.scrollIntoView();
   };
@@ -94,7 +93,11 @@ const LandingPage = (): React.ReactElement => {
             value: filter.value
           }}
           disabled={isEmptyList}
-          onChange={(option: StatusFilter) => setFilter(option)}
+          onChange={(option: StatusFilter) => {
+            setFilter(option);
+            // Reset the pagination when filtering
+            handlePageChange(0);
+          }}
         />
       </div>
       <div className="rectification-list">
@@ -117,7 +120,10 @@ const LandingPage = (): React.ReactElement => {
       )}
       <Pagination
         language="fi"
-        onChange={(event, index) => handlePageChange(event, index)}
+        onChange={(event, index) => {
+          event.preventDefault();
+          handlePageChange(index);
+        }}
         pageCount={Math.ceil(filteredRectifications.length / elementsOnPage)}
         pageHref={() => '#'}
         pageIndex={pageIndex}


### PR DESCRIPTION
This PR fixes the issue that caused some results to not be shown in the rectification list when filtering by a status after a page change, by resetting the pagination when a filter is selected.