### PR TITLE
Fix loading spinner on mobile

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -7,9 +7,11 @@ const Loader = (): React.ReactElement => {
   return (
     <div
       style={{
-        position: 'absolute',
-        top: '30%',
-        left: '50%'
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        zIndex: 999,
+        transform: 'translate(-50%, -50%)'
       }}>
       <LoadingSpinner loadingText={t('common:loading')} />
     </div>

--- a/src/components/styles.module.css
+++ b/src/components/styles.module.css
@@ -11,6 +11,7 @@
   margin: 0 auto var(--spacing-xl);
   padding: 12px;
   width: 90%;
+  min-height: 70vh;
 }
 
 .content-element {


### PR DESCRIPTION
This PR fixes the loading spinner on mobile. Previously it was not centered and partially hidden behind other elements.