### PR TITLE
General fixes

### DIFF
--- a/src/components/extendDueDate/ExtendDueDate.test.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.test.tsx
@@ -13,6 +13,7 @@ import '@testing-library/jest-dom';
 import { t } from 'i18next';
 import { formatDate, formatISODate, getNewDueDate } from '../../utils/helpers';
 import { ClientContext } from '../../client/ClientProvider';
+import { BrowserRouter } from 'react-router-dom';
 
 // ClientContext needs to be added here since the tests don't get it from FormStepper
 renderHook(() => useContext(ClientContext));
@@ -20,9 +21,11 @@ renderHook(() => useContext(ClientContext));
 describe('extend due date form', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
-      <Provider store={store}>
-        <ExtendDueDate />
-      </Provider>
+      <BrowserRouter>
+        <Provider store={store}>
+          <ExtendDueDate />
+        </Provider>
+      </BrowserRouter>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -30,11 +33,13 @@ describe('extend due date form', () => {
   describe('renders ', () => {
     test('first step view correctly', async () => {
       render(
-        <Provider store={store}>
-          <I18nextProvider i18n={i18n}>
-            <ExtendDueDate />
-          </I18nextProvider>
-        </Provider>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <ExtendDueDate />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
       );
 
       // Form title is visible

--- a/src/components/formStepper/FormStepper.test.tsx
+++ b/src/components/formStepper/FormStepper.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { axe } from 'jest-axe';
@@ -9,6 +10,7 @@ import { configureStore, createSlice } from '@reduxjs/toolkit';
 import store from '../../store';
 import '@testing-library/jest-dom';
 import { t } from 'i18next';
+import { BrowserRouter } from 'react-router-dom';
 
 const mockAction = jest.fn(() => {
   // Mock function
@@ -72,12 +74,14 @@ const userSliceMock = createSlice({
 describe('form stepper', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
-      <Provider store={store}>
-        <FormStepper
-          initialSteps={formStepperSliceMock.getInitialState().steps}
-          onSubmit={mockAction}
-        />
-      </Provider>
+      <BrowserRouter>
+        <Provider store={store}>
+          <FormStepper
+            initialSteps={formStepperSliceMock.getInitialState().steps}
+            onSubmit={mockAction}
+          />
+        </Provider>
+      </BrowserRouter>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -93,14 +97,16 @@ describe('form stepper', () => {
     });
 
     render(
-      <Provider store={store}>
-        <I18nextProvider i18n={i18n}>
-          <FormStepper
-            initialSteps={formStepperSliceMock.getInitialState().steps}
-            onSubmit={mockAction}
-          />
-        </I18nextProvider>
-      </Provider>
+      <BrowserRouter>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <FormStepper
+              initialSteps={formStepperSliceMock.getInitialState().steps}
+              onSubmit={mockAction}
+            />
+          </I18nextProvider>
+        </Provider>
+      </BrowserRouter>
     );
 
     // Check that the correct step is rendered
@@ -114,15 +120,24 @@ describe('form stepper', () => {
     });
     expect(secondStepHeading).toBeNull();
 
-    // Check that both buttons are visible but previous button is disabled
-    const previousButton = screen.getByRole('button', {
+    // Check that both buttons are visible and enabled
+
+    // 'previous' button should have role 'link' instead of 'button'
+    // since it takes user to the landing page
+    const previousButton = screen.queryByRole('button', {
       name: t('common:previous')
     });
-    expect(previousButton).toBeInTheDocument();
-    expect(previousButton).toBeDisabled();
+    expect(previousButton).not.toBeInTheDocument();
+
+    const previousButtonLink = screen.queryByRole('link', {
+      name: t('common:previous')
+    });
+    expect(previousButtonLink).toBeInTheDocument();
+    expect(previousButtonLink).toBeEnabled();
 
     const nextButton = screen.getByRole('button', { name: t('common:next') });
     expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toBeEnabled();
 
     await waitFor(() => {
       nextButton.click();
@@ -164,14 +179,16 @@ describe('form stepper', () => {
     });
 
     render(
-      <Provider store={store}>
-        <I18nextProvider i18n={i18n}>
-          <FormStepper
-            initialSteps={formStepperSliceMock.getInitialState().steps}
-            onSubmit={mockAction}
-          />
-        </I18nextProvider>
-      </Provider>
+      <BrowserRouter>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <FormStepper
+              initialSteps={formStepperSliceMock.getInitialState().steps}
+              onSubmit={mockAction}
+            />
+          </I18nextProvider>
+        </Provider>
+      </BrowserRouter>
     );
 
     // Check that the correct step is rendered

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import {
@@ -23,6 +24,7 @@ import {
   selectStepperState,
   setActive,
   setSteps,
+  disablePreviousSteps,
   Step
 } from './formStepperSlice';
 import {
@@ -74,6 +76,7 @@ const useRectificationForm = () => {
 const FormStepper = (props: Props): React.ReactElement => {
   // ClientContext is needed to get user profile
   useContext(ClientContext);
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { activeStepIndex, steps } = useSelector(selectStepperState);
@@ -88,6 +91,7 @@ const FormStepper = (props: Props): React.ReactElement => {
 
   const handleFormSubmit = () => {
     dispatch(setFormSubmitted(true));
+    dispatch(disablePreviousSteps(activeStepIndex));
     setShowSubmitNotification(true);
   };
 
@@ -143,22 +147,26 @@ const FormStepper = (props: Props): React.ReactElement => {
             <Button
               id="button-previous"
               className="button"
-              disabled={activeStepIndex === 0 || formContent.formSubmitted}
+              role={activeStepIndex === 0 ? 'link' : 'button'}
+              disabled={formContent.formSubmitted}
               iconLeft={<IconArrowLeft />}
-              onClick={() => dispatch(setActive(activeStepIndex - 1))}
+              onClick={() =>
+                activeStepIndex === 0
+                  ? navigate('/')
+                  : dispatch(setActive(activeStepIndex - 1))
+              }
               variant="secondary">
               {t('common:previous')}
             </Button>
             {activeStepIndex === 1 && !lastStep && (
-              <a id="button-home" className="button link" href="/">
-                <Button
-                  className="button"
-                  iconRight={<IconHome />}
-                  role="link"
-                  variant="secondary">
-                  {t('common:to-mainpage')}
-                </Button>
-              </a>
+              <Button
+                className="button link"
+                iconRight={<IconHome />}
+                role="link"
+                variant="secondary"
+                onClick={() => navigate('/')}>
+                {t('common:to-mainpage')}
+              </Button>
             )}
             <div className="submit-and-print-button-wrapper">
               {lastStep && formContent.selectedForm !== 'due-date' && (
@@ -223,15 +231,14 @@ const FormStepper = (props: Props): React.ReactElement => {
           <div>
             {lastStep && formContent.formSubmitted && (
               <div ref={mainPageButtonRef} className="home-button-container">
-                <a className="button link" href="/">
-                  <Button
-                    className="button home"
-                    iconRight={<IconHome />}
-                    role="link"
-                    variant="primary">
-                    {t('common:to-mainpage')}
-                  </Button>
-                </a>
+                <Button
+                  className="button home link"
+                  iconRight={<IconHome />}
+                  role="link"
+                  variant="primary"
+                  onClick={() => navigate('/')}>
+                  {t('common:to-mainpage')}
+                </Button>
               </div>
             )}
           </div>

--- a/src/components/formStepper/formStepperSlice.tsx
+++ b/src/components/formStepper/formStepperSlice.tsx
@@ -67,12 +67,28 @@ export const slice = createSlice({
         }
         return step;
       });
+    },
+    disablePreviousSteps: (state, action) => {
+      state.steps = state.steps.map((step: Step, index: number) => {
+        if (index !== action.payload) {
+          return {
+            state: StepState.disabled,
+            label: step.label
+          };
+        }
+        return step;
+      });
     }
   }
 });
 
 // Actions
-export const { completeStep, setActive, setSteps } = slice.actions;
+export const {
+  completeStep,
+  setActive,
+  setSteps,
+  disablePreviousSteps
+} = slice.actions;
 
 // Selectors
 export const selectStepperState = (state: RootState) => state.formStepper;

--- a/src/components/landingPage/LandingPage.test.tsx
+++ b/src/components/landingPage/LandingPage.test.tsx
@@ -95,9 +95,7 @@ describe('landing page', () => {
       );
       expect(rectificationList[0]).toHaveTextContent(/23456789/);
       expect(rectificationList[0]).toHaveTextContent(/Vastaanotettu/);
-      expect(rectificationList[0]).toHaveTextContent(
-        /Viimeksi muokattu 11.2.2023/
-      );
+      expect(rectificationList[0]).toHaveTextContent(/11.2.2023/);
 
       // 7 results in total, 5 results shown on the main page
       expect(rectificationList.length).toBe(5);
@@ -130,18 +128,14 @@ describe('landing page', () => {
     expect(sortButton).toBeVisible();
     expect(sortButton).toHaveTextContent(t('landing-page:newest-first'));
 
-    expect(rectificationList[0]).toHaveTextContent(
-      /Viimeksi muokattu 11.2.2023/
-    );
+    expect(rectificationList[0]).toHaveTextContent(/11.2.2023/);
 
     // 'Sort by date' button is clicked
     fireEvent.click(sortButton);
 
     expect(sortButton).toHaveTextContent(t('landing-page:oldest-first'));
     expect(rectificationList.length).toBe(5);
-    expect(rectificationList[0]).toHaveTextContent(
-      /Viimeksi muokattu 20.11.2021/
-    );
+    expect(rectificationList[0]).toHaveTextContent(/20.11.2021/);
   });
 
   test('filters results correctly by status', async () => {

--- a/src/components/movedCarAppeal/MovedCarAppeal.test.tsx
+++ b/src/components/movedCarAppeal/MovedCarAppeal.test.tsx
@@ -8,13 +8,16 @@ import { Provider } from 'react-redux';
 import store from '../../store';
 import '@testing-library/jest-dom';
 import { t } from 'i18next';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('moved car appeal form', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
-      <Provider store={store}>
-        <MovedCarAppeal />
-      </Provider>
+      <BrowserRouter>
+        <Provider store={store}>
+          <MovedCarAppeal />
+        </Provider>
+      </BrowserRouter>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -22,11 +25,13 @@ describe('moved car appeal form', () => {
   describe('renders ', () => {
     test('first step view correctly', async () => {
       render(
-        <Provider store={store}>
-          <I18nextProvider i18n={i18n}>
-            <MovedCarAppeal />
-          </I18nextProvider>
-        </Provider>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <MovedCarAppeal />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
       );
 
       // Form title is visible

--- a/src/components/rectificationListRow/RectificationListRow.css
+++ b/src/components/rectificationListRow/RectificationListRow.css
@@ -19,7 +19,6 @@
   grid-row: 1;
   display: flex;
   align-items: center;
-  font-size: 15px;
   line-height: 20px;
   color: var(--color-black-60);
 }
@@ -80,7 +79,7 @@
   }
 
   .rectification-list-row-date {
-    grid-column: 10 / 14;
+    grid-column: 11 / 14;
     grid-row: 1;
   }
 }

--- a/src/components/rectificationListRow/RectificationListRow.tsx
+++ b/src/components/rectificationListRow/RectificationListRow.tsx
@@ -29,9 +29,7 @@ const RectificationListRow: FC<Props> = ({ form }): React.ReactElement => {
     <>
       <div className="rectification-list-row">
         <div className="rectification-list-row-date">
-          {`${t('landing-page:list:last-edited')} ${formatDateTime(
-            form.edited
-          )}`}
+          {formatDateTime(form.edited)}
         </div>
         <div className="rectification-list-row-title">
           {`${t(`${form.type}:title`)} (${form.id})`}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -296,7 +296,6 @@
           }
         }
       },
-      "last-edited": "Viimeksi muokattu",
       "show-more": "Näytä lisää",
       "show-less": "Näytä vähemmän",
       "no-forms": "Et ole tehnyt yhtään oikaisuvaatimusta tai siirtänyt pysäköintivirhemaksun eräpäivää."


### PR DESCRIPTION
This PR makes the following small fixes:
* Remove the unnecessary "last edited" text from the dates on rectification form list
* Disable the previous steps of Stepper component when a form is submitted to disallow editing a submitted form
* Set the "previous" button on the first page of all forms to take back to the landing page instead of being disabled