### PR TITLE
Fix CustomAccordion styling

### DIFF
--- a/src/components/customAccordion/CustomAccordion.css
+++ b/src/components/customAccordion/CustomAccordion.css
@@ -5,17 +5,14 @@
 
 .custom-accordion {
   margin-top: var(--spacing-m);
-  color: black;
+  color: black !important;
   background-color: transparent !important;
-  padding: 0;
-  margin: 0;
-  width: 100%;
+  padding: 0 !important;
+  width: 100% !important;
 }
 
 .custom-accordion-header {
-  margin-top: var(--spacing-m);
-  width: 100%;
-  justify-content: space-between;
+  justify-content: space-between !important;
   margin-bottom: var(--spacing-s) !important;
 }
 
@@ -34,7 +31,7 @@
 }
 
 .custom-accordion.close {
-  justify-content: flex-end;
-  height: 20px;
+  justify-content: flex-end !important;
+  height: 20px !important;
   margin-top: var(--spacing-xs);
 }


### PR DESCRIPTION
This PR fixes `CustomAccordion` styling. Some of the style properties were overrode by HDS's button style properties (on dev environment), so `!important` is added to the affected properties.