### PR TITLE
Get and show data from getTransferData endpoint

### DIFF
--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -156,7 +156,8 @@ export const slice = createSlice({
     // GET FoulData
     builder.addCase(getFoulDataThunk.fulfilled, (state, action) => ({
       ...state,
-      foulData: action.payload
+      foulData: action.payload,
+      formError: null
     }));
     builder.addCase(getFoulDataThunk.rejected, (state, action) => ({
       ...state,
@@ -165,7 +166,8 @@ export const slice = createSlice({
     // GET TransferData
     builder.addCase(getTransferDataThunk.fulfilled, (state, action) => ({
       ...state,
-      transferData: action.payload
+      transferData: action.payload,
+      formError: null
     }));
     builder.addCase(getTransferDataThunk.rejected, (state, action) => ({
       ...state,

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -3,8 +3,12 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../../store';
 import { Control } from 'react-hook-form';
 import { FoulData, FoulRequest } from '../../interfaces/foulInterfaces';
-import { TransferData } from '../../interfaces/transferInterfaces';
+import {
+  TransferData,
+  TransferRequest
+} from '../../interfaces/transferInterfaces';
 import { getFoulData } from '../../services/foulService';
+import { getTransferData } from '../../services/transferService';
 import { AxiosError } from 'axios';
 import { completeStep } from '../formStepper/formStepperSlice';
 
@@ -98,12 +102,27 @@ export const getFoulDataThunk = createAsyncThunk(
       )
 );
 
+export const getTransferDataThunk = createAsyncThunk(
+  'formContent/getTransferData',
+  async (req: TransferRequest, thunkAPI) =>
+    await getTransferData(req)
+      .then(res => {
+        const activeStep = (thunkAPI.getState() as RootState).formStepper
+          .activeStepIndex;
+        thunkAPI.dispatch(completeStep(activeStep));
+        return res;
+      })
+      .catch((err: AxiosError) =>
+        thunkAPI.rejectWithValue(err.response?.status)
+      )
+);
+
 const handleFormError = (status: number | undefined) => {
   if (status) {
     switch (status) {
       case 404:
       case 422:
-        return 'foul-not-found';
+        return 'not-found';
       // 500, 503 etc.
       default:
         return 'unknown';
@@ -140,6 +159,15 @@ export const slice = createSlice({
       foulData: action.payload
     }));
     builder.addCase(getFoulDataThunk.rejected, (state, action) => ({
+      ...state,
+      formError: handleFormError(action.payload as number | undefined)
+    }));
+    // GET TransferData
+    builder.addCase(getTransferDataThunk.fulfilled, (state, action) => ({
+      ...state,
+      transferData: action.payload
+    }));
+    builder.addCase(getTransferDataThunk.rejected, (state, action) => ({
       ...state,
       formError: handleFormError(action.payload as number | undefined)
     }));

--- a/src/components/formStepper/FormStepper.css
+++ b/src/components/formStepper/FormStepper.css
@@ -2,6 +2,31 @@
   scroll-margin: var(--spacing-s);
 }
 
+.button {
+  height: 56px;
+}
+
+.button.submit {
+  min-width: 137px;
+}
+
+.submit-notification {
+  margin-bottom: 24px;
+  z-index: 100;
+}
+
+.button.home {
+  width: 100%;
+}
+
+.button.link {
+  text-decoration: none;
+}
+
+.form-error-label {
+  max-width: 500px;
+}
+
 @media (max-width: 767px) {
   #stepper div div:nth-child(2) {
     font-size: 24px;
@@ -68,25 +93,4 @@
   .button-wrapper.submit {
     justify-content: space-between;
   }
-}
-
-.button {
-  height: 56px;
-}
-
-.button.submit {
-  min-width: 137px;
-}
-
-.submit-notification {
-  margin-bottom: 24px;
-  z-index: 100;
-}
-
-.button.home {
-  width: 100%;
-}
-
-.button.link {
-  text-decoration: none;
 }

--- a/src/components/infoContainer/InfoContainer.tsx
+++ b/src/components/infoContainer/InfoContainer.tsx
@@ -4,14 +4,13 @@ import { FormId, selectFormContent } from '../formContent/formContentSlice';
 import CarInfoCard from '../carInfoCard/CarInfoCard';
 import ParkingFineSummary from '../parkingFineSummary/ParkingFineSummary';
 import ReimbursementSummary from '../reimbursementSummary/ReimbursementSummary';
-import mockTransferData from '../../mocks/mockTransferData';
 import './InfoContainer.css';
 
 const InfoContainer = (): React.ReactElement => {
   const formContent = useSelector(selectFormContent);
   const selectedForm = formContent.selectedForm;
   const foulData = formContent.foulData;
-  const transferData = mockTransferData; /* TODO: get data from /getTransferData endpoint */
+  const transferData = formContent.transferData;
 
   const selectForm = (selectedForm: FormId) => {
     switch (selectedForm) {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -74,10 +74,6 @@
       "fine-additional-details": "Pysäköintivirheen lisätiedot",
       "sum": "Pysäköintivirhemaksun summa",
       "due-date": "Eräpäivä"
-    },
-    "errors": {
-      "foul-not-found": "Virhemaksun tietoja ei löydy. Tarkista tiedot.",
-      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
     }
   },
   "parking-fine": {
@@ -106,7 +102,11 @@
         "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
       }
     },
-    "submit": "Lähetä"
+    "submit": "Lähetä",
+    "errors": {
+      "not-found": "Pysäköintivirhemaksun tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
+      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+    }
   },
   "due-date": {
     "title": "Pysäköintivirhemaksun eräpäivän siirto 30 päivällä",
@@ -133,7 +133,11 @@
         "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on {{newDueDate}}."
       }
     },
-    "submit": "Siirrä eräpäivää"
+    "submit": "Siirrä eräpäivää",
+    "errors": {
+      "not-found": "Pysäköintivirhemaksun tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
+      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+    }
   },
   "moved-car": {
     "title": "Ajoneuvon siirron oikaisuvaatimus",
@@ -158,7 +162,11 @@
     "start-address-details": "Lähtöosoitteen lisätiedot",
     "end-address": "Siirron pääteosoite",
     "end-address-details": "Päätesoitteen lisätiedot",
-    "reimbursement-sum": "Korvauspäätöksen summa"
+    "reimbursement-sum": "Korvauspäätöksen summa",
+    "errors": {
+      "not-found": "Ajoneuvon siirron korvauspäätöksen tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
+      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+    }
   },
   "rectificationForm": {
     "relation-info": {

--- a/src/interfaces/transferInterfaces.ts
+++ b/src/interfaces/transferInterfaces.ts
@@ -1,5 +1,10 @@
 import { Foul, FoulAttachment } from './foulInterfaces';
 
+export interface TransferRequest {
+  transfer_number: string;
+  register_number: string;
+}
+
 export interface TransferData {
   transferNumber: number;
   transferDate: string;

--- a/src/services/transferService.ts
+++ b/src/services/transferService.ts
@@ -1,0 +1,15 @@
+import {
+  TransferData,
+  TransferRequest
+} from '../interfaces/transferInterfaces';
+import axios, { AxiosError } from 'axios';
+
+const api_url = window._env_.REACT_APP_API_URL;
+
+export const getTransferData = async (
+  params: TransferRequest
+): Promise<TransferData> =>
+  axios
+    .get(`${api_url}/getTransferData`, { params })
+    .then(res => res.data)
+    .catch((err: AxiosError) => Promise.reject(err));


### PR DESCRIPTION
This PR fetches data from `getTransferData` endpoint and shows it on the moved car appeal form. If the data is not found from PASI, it displays an error message similarly than the parking fine appeal form:

<img width="277" alt="Screenshot 2023-03-24 at 11 56 26" src="https://user-images.githubusercontent.com/36920208/227492041-701a6682-461e-47a2-b8c1-7de45166d4fa.png">

This PR also updates the `404` error message of `getFoulData`.

TODO:
* Add loading spinner that shows that the request is being processed