### PR TITLE
Show loading spinner when requests are being processed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Button, Dialog, IconInfoCircle } from 'hds-react';
 import { getClient } from './client/oidc-react';
 import { useTranslation } from 'react-i18next';
 import { selectPromptLogin, setPromptLogin } from './components/user/userSlice';
+import RequestLoader from './components/loader/RequestLoader';
 
 function App(): React.ReactElement {
   const { t } = useTranslation();
@@ -29,6 +30,7 @@ function App(): React.ReactElement {
 
   return (
     <PageContainer>
+      <RequestLoader />
       {promptLogin && (
         <Dialog
           id="session-end-dialog"

--- a/src/BrowserApp.tsx
+++ b/src/BrowserApp.tsx
@@ -6,7 +6,11 @@ import App from './App';
 import { ClientProvider } from './client/ClientProvider';
 import StoreProvider from './client/redux/StoreProvider';
 import HandleCallback from './components/HandleCallback';
-import store from './store';
+import { setupStore } from './store';
+import { injectStore } from './utils/interceptors';
+
+const store = setupStore();
+injectStore(store);
 
 function BrowserApp(): React.ReactElement {
   return (

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoginInfo from './LoginInfo';
-import Loader from './Loader';
+import Loader from './loader/Loader';
 import WithAuth from '../client/WithAuth';
 
 const Login = (): React.ReactElement => (

--- a/src/components/loader/Loader.css
+++ b/src/components/loader/Loader.css
@@ -1,0 +1,7 @@
+.loading-spinner {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 999;
+  transform: translate(-50%, -50%);
+}

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { LoadingSpinner } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import './Loader.css';
 
+/**
+ * An overlay component that is used
+ * * on LandingPage when the user info is being retrieved
+ * * by RequestLoader when redux loading.isLoading = true
+ */
 const Loader = (): React.ReactElement => {
   const { t } = useTranslation();
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: '50%',
-        left: '50%',
-        zIndex: 999,
-        transform: 'translate(-50%, -50%)'
-      }}>
+    <div className="loading-spinner">
       <LoadingSpinner loadingText={t('common:loading')} />
     </div>
   );

--- a/src/components/loader/RequestLoader.tsx
+++ b/src/components/loader/RequestLoader.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react';
+import { selectIsLoading } from './loadingSlice';
+import { useSelector } from 'react-redux';
+import Loader from './Loader';
+
+/**
+ * An overlay component for App.tsx that becomes visible when redux loading.isLoading = true.
+ * The loading state is triggered in the axios interceptor.
+ */
+const RequestLoader: FC = () => {
+  const isLoading = useSelector(selectIsLoading);
+
+  return <>{isLoading && <Loader />}</>;
+};
+
+export default RequestLoader;

--- a/src/components/loader/loadingSlice.tsx
+++ b/src/components/loader/loadingSlice.tsx
@@ -1,0 +1,28 @@
+import { RootState } from '../../store';
+import { createSlice } from '@reduxjs/toolkit';
+
+interface LoadingState {
+  isLoading: boolean;
+}
+
+const initialState: LoadingState = {
+  isLoading: false
+};
+
+export const slice = createSlice({
+  name: 'loading',
+  initialState,
+  reducers: {
+    setLoading: state => {
+      state.isLoading = true;
+    },
+    clearLoading: state => {
+      state.isLoading = false;
+    }
+  }
+});
+
+export const selectIsLoading = (state: RootState) => state.loading.isLoading;
+
+export const { setLoading, clearLoading } = slice.actions;
+export default slice.reducer;

--- a/src/pages/LogOut.tsx
+++ b/src/pages/LogOut.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import PageContent from '../components/PageContent';
 import WithAuth from '../client/WithAuth';
-import Loader from '../components/Loader';
+import Loader from '../components/loader/Loader';
 import LoggedOutInfo from '../components/LoggedOutInfo';
 import { useTranslation } from 'react-i18next';
 

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,22 +1,35 @@
-import { configureStore } from '@reduxjs/toolkit';
+import {
+  combineReducers,
+  configureStore,
+  PreloadedState
+} from '@reduxjs/toolkit';
 import formContentReducer from './components/formContent/formContentSlice';
 import formStepperReducer from './components/formStepper/formStepperSlice';
 import extendDueDateFormReducer from './components/extendDueDate/extendDueDateFormSlice';
 import userReducer from './components/user/userSlice';
+import loadingReducer from './components/loader/loadingSlice';
 import { useDispatch } from 'react-redux';
 
-const store = configureStore({
-  reducer: {
-    formContent: formContentReducer,
-    formStepper: formStepperReducer,
-    extendDueDateForm: extendDueDateFormReducer,
-    user: userReducer
-  }
-});
+export const storeItems = {
+  formContent: formContentReducer,
+  formStepper: formStepperReducer,
+  extendDueDateForm: extendDueDateFormReducer,
+  user: userReducer,
+  loading: loadingReducer
+};
 
-export default store;
-export type RootState = ReturnType<typeof store.getState>;
+const rootReducer = combineReducers(storeItems);
 
-export type AppDispatch = typeof store.dispatch;
+export const setupStore = (preloadedState?: PreloadedState<RootState>) =>
+  configureStore({
+    reducer: rootReducer,
+    preloadedState
+  });
+
+export default setupStore();
+export type RootState = ReturnType<typeof rootReducer>;
+export type AppStore = ReturnType<typeof setupStore>;
+
+export type AppDispatch = AppStore['dispatch'];
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();

--- a/src/utils/interceptors.ts
+++ b/src/utils/interceptors.ts
@@ -1,0 +1,51 @@
+import { AppStore } from '../store';
+import axios, {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig
+} from 'axios';
+import { clearLoading, setLoading } from '../components/loader/loadingSlice';
+
+let store: AppStore;
+
+export const injectStore = (_store: AppStore) => {
+  store = _store;
+};
+
+/**
+ * Intercepts axios requests and responses before they are handled by the services.
+ * It is used for displaying a loading spinner when requests are being processed
+ * for now, but can also be used to handle errors etc.
+ * This interceptor is imported directly into BrowserApp.
+ */
+
+// Request interceptor
+axios.interceptors.request.use(
+  request => handleRequest(request),
+  error => handleError(error)
+);
+
+// Response interceptor
+axios.interceptors.response.use(
+  response => handleResponse(response),
+  error => handleError(error)
+);
+
+const handleRequest = (req: InternalAxiosRequestConfig) => {
+  if (!store.getState().loading.isLoading) {
+    store.dispatch(setLoading());
+  }
+  return req;
+};
+
+const handleResponse = (res: AxiosResponse) => {
+  if (store.getState().loading.isLoading) {
+    store.dispatch(clearLoading());
+  }
+  return res;
+};
+
+const handleError = (error: AxiosError) => {
+  store.dispatch(clearLoading());
+  return Promise.reject(error);
+};


### PR DESCRIPTION
This PR adds a loading spinner that is displayed as overlay component when a (axios) request is being processed. It uses the same HDS's `LoadingSpinner` component that `LandingPage` uses when user info is being retrieved, but it is triggered differently.

https://user-images.githubusercontent.com/36920208/227543579-263acb2a-0e18-49f2-a266-500744a6c13b.mov
