### PR TITLE
Add error handling based on the response code from PASI

### DIFF
--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -117,18 +117,14 @@ export const getTransferDataThunk = createAsyncThunk(
       )
 );
 
-const handleFormError = (status: number | undefined) => {
-  if (status) {
-    switch (status) {
-      case 404:
-      case 422:
-        return 'not-found';
-      // 500, 503 etc.
-      default:
-        return 'unknown';
-    }
-  } else {
-    return 'unknown';
+const handleFormError = (status: number | undefined, form: FormId) => {
+  switch (status) {
+    case 404:
+    case 422:
+      return `${form}:errors:not-found`;
+    // 500, 503 etc.
+    default:
+      return 'common:errors:unknown';
   }
 };
 
@@ -161,7 +157,10 @@ export const slice = createSlice({
     }));
     builder.addCase(getFoulDataThunk.rejected, (state, action) => ({
       ...state,
-      formError: handleFormError(action.payload as number | undefined)
+      formError: handleFormError(
+        action.payload as number | undefined,
+        FormId.PARKINGFINE
+      )
     }));
     // GET TransferData
     builder.addCase(getTransferDataThunk.fulfilled, (state, action) => ({
@@ -171,7 +170,10 @@ export const slice = createSlice({
     }));
     builder.addCase(getTransferDataThunk.rejected, (state, action) => ({
       ...state,
-      formError: handleFormError(action.payload as number | undefined)
+      formError: handleFormError(
+        action.payload as number | undefined,
+        FormId.MOVEDCAR
+      )
     }));
   }
 });

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -41,6 +41,7 @@ import {
 import { selectDueDateFormValues } from '../extendDueDate/extendDueDateFormSlice';
 import { setUserProfile } from '../user/userSlice';
 import ErrorLabel from '../errorLabel/ErrorLabel';
+import { ResponseCode } from '../../interfaces/foulInterfaces';
 import './FormStepper.css';
 
 interface Props {
@@ -88,6 +89,10 @@ const FormStepper = (props: Props): React.ReactElement => {
   const formContent = useSelector(selectFormContent);
   const selectedForm = formContent.selectedForm;
   const formError = formContent.formError;
+  const responseCode =
+    selectedForm === FormId.MOVEDCAR
+      ? formContent.transferData?.responseCode
+      : formContent.foulData?.responseCode;
   const dueDateFormValues = useSelector(selectDueDateFormValues);
   const lastStep = activeStepIndex === steps.length - 1;
   const [showSubmitNotification, setShowSubmitNotification] = useState(false);
@@ -176,9 +181,7 @@ const FormStepper = (props: Props): React.ReactElement => {
           values={getValues}
         />
         <div className="form-error-label">
-          {formError && (
-            <ErrorLabel text={t(`${selectedForm}:errors:${formError}`)} />
-          )}
+          {formError && <ErrorLabel text={t(formError)} />}
         </div>
         <div className="button-container">
           <div className={`button-wrapper ${lastStep ? 'submit' : ''}`}>
@@ -224,7 +227,11 @@ const FormStepper = (props: Props): React.ReactElement => {
                   className="button"
                   iconRight={<IconArrowRight />}
                   onClick={handleSubmit(handleNextClick)}
-                  variant="primary">
+                  variant="primary"
+                  disabled={
+                    activeStepIndex === 1 &&
+                    responseCode !== ResponseCode.Success
+                  }>
                   {activeStepIndex === 1
                     ? t('common:make-rectification')
                     : t('common:next')}

--- a/src/components/infoContainer/InfoContainer.css
+++ b/src/components/infoContainer/InfoContainer.css
@@ -10,6 +10,11 @@
   max-width: 100%;
 }
 
+.error-notification {
+  width: 100%;
+  margin-bottom: var(--spacing-m);
+}
+
 @media (min-width: 768px) {
   .summary-container {
     display: grid;

--- a/src/components/infoContainer/InfoContainer.tsx
+++ b/src/components/infoContainer/InfoContainer.tsx
@@ -1,37 +1,79 @@
-import React from 'react';
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Notification } from 'hds-react';
 import { FormId, selectFormContent } from '../formContent/formContentSlice';
 import CarInfoCard from '../carInfoCard/CarInfoCard';
 import ParkingFineSummary from '../parkingFineSummary/ParkingFineSummary';
 import ReimbursementSummary from '../reimbursementSummary/ReimbursementSummary';
+import { FoulData, ResponseCode } from '../../interfaces/foulInterfaces';
+import { TransferData } from '../../interfaces/transferInterfaces';
 import './InfoContainer.css';
 
 const InfoContainer = (): React.ReactElement => {
+  const { t } = useTranslation();
   const formContent = useSelector(selectFormContent);
   const selectedForm = formContent.selectedForm;
-  const foulData = formContent.foulData;
-  const transferData = formContent.transferData;
+  const data =
+    selectedForm === FormId.MOVEDCAR
+      ? formContent.transferData
+      : formContent.foulData;
+  const [errorNotificationOpen, setErrorNotificationOpen] = useState(false);
+
+  useEffect(() => {
+    data && setErrorNotificationOpen(data?.responseCode !== 0);
+  }, [data]);
 
   const selectForm = (selectedForm: FormId) => {
     switch (selectedForm) {
-      case 'parking-fine':
+      case FormId.PARKINGFINE:
         return (
           <>
-            <ParkingFineSummary foulData={foulData} />
-            <CarInfoCard data={foulData} />
+            <ParkingFineSummary foulData={data as FoulData} />
+            <CarInfoCard data={data} />
           </>
         );
-      case 'moved-car':
+      case FormId.MOVEDCAR:
         return (
           <>
-            <ReimbursementSummary transferData={transferData} />
-            <CarInfoCard data={transferData} />
+            <ReimbursementSummary transferData={data as TransferData} />
+            <CarInfoCard data={data} />
           </>
         );
     }
   };
 
-  return <div className="info-container">{selectForm(selectedForm)}</div>;
+  const getErrorMessage = (error: ResponseCode | undefined) => {
+    switch (error) {
+      case ResponseCode.ObjectionExists:
+        return `${selectedForm}:errors:objection-exists`;
+      case ResponseCode.FoulIsANote:
+        return 'parking-fine:errors:note';
+      default:
+        return 'common:errors:default';
+    }
+  };
+
+  return (
+    <>
+      <h2 className="show-on-print" aria-hidden="true">
+        {t(`${selectedForm}:stepper:step2`)}
+      </h2>
+      {errorNotificationOpen && (
+        <Notification
+          label={t('common:errors:notification-title')}
+          type="error"
+          dismissible
+          className="error-notification"
+          closeButtonLabelText={t('common:close-notification') as string}
+          onClose={() => setErrorNotificationOpen(false)}>
+          {t(getErrorMessage(data?.responseCode))}
+        </Notification>
+      )}
+      <div className="info-container">{selectForm(selectedForm)}</div>
+    </>
+  );
 };
 
 export default InfoContainer;

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -46,9 +46,6 @@ const ParkingFineSummary: FC<Props> = ({ foulData }) => {
   return (
     <div className="summary-body">
       <div data-testid="parkingFineSummary" className="summary-container">
-        <h2 className="show-on-print" aria-hidden="true">
-          {t('parking-fine:fine-info')}
-        </h2>
         <div className="info-field">
           <label>{t('common:fine-info:fine-timestamp')}</label>
           <p>{foulData?.foulDate && formatDateTime(foulData.foulDate)}</p>

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -9,12 +9,6 @@ exports[`Component matches snapshot 1`] = `
       class="summary-container"
       data-testid="parkingFineSummary"
     >
-      <h2
-        aria-hidden="true"
-        class="show-on-print"
-      >
-        Pysäköintivirhemaksun tiedot
-      </h2>
       <div
         class="info-field"
       >

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -8,7 +8,6 @@ import InfoContainer from '../infoContainer/InfoContainer';
 import CustomAccordion from '../customAccordion/CustomAccordion';
 import {
   FileItem,
-  FormId,
   selectFormContent,
   selectFormValues
 } from '../formContent/formContentSlice';
@@ -160,12 +159,7 @@ const RectificationSummary = () => {
         </div>
       </div>
       <div className="hide-on-print">
-        <CustomAccordion
-          heading={
-            selectedForm === FormId.MOVEDCAR
-              ? t('moved-car:stepper:step2')
-              : t('parking-fine:fine-info')
-          }>
+        <CustomAccordion heading={t(`${selectedForm}:stepper:step2`)}>
           <InfoContainer />
         </CustomAccordion>
       </div>

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -391,6 +391,12 @@ exports[`Component matches snapshot 1`] = `
     aria-hidden="true"
     class="show-on-print"
   >
+    <h2
+      aria-hidden="true"
+      class="show-on-print"
+    >
+      Pysäköintivirhemaksun tiedot
+    </h2>
     <div
       class="info-container"
     >
@@ -401,12 +407,6 @@ exports[`Component matches snapshot 1`] = `
           class="summary-container"
           data-testid="parkingFineSummary"
         >
-          <h2
-            aria-hidden="true"
-            class="show-on-print"
-          >
-            Pysäköintivirhemaksun tiedot
-          </h2>
           <div
             class="info-field"
           >

--- a/src/components/reimbursementSummary/ReimbursementSummary.tsx
+++ b/src/components/reimbursementSummary/ReimbursementSummary.tsx
@@ -22,9 +22,6 @@ const ReimbursementSummary: FC<Props> = ({ transferData }) => {
   return (
     <div className="summary-body">
       <div data-testid="reimbursementSummary" className="summary-container">
-        <h2 className="show-on-print" aria-hidden="true">
-          {t('moved-car:stepper:step2')}
-        </h2>
         <div className="info-field">
           <label>{t('moved-car:move-timestamp')}</label>
           <p>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -74,11 +74,15 @@
       "fine-additional-details": "Pysäköintivirheen lisätiedot",
       "sum": "Pysäköintivirhemaksun summa",
       "due-date": "Eräpäivä"
+    },
+    "errors": {
+      "notification-title": "Et voi tehdä oikaisuvaatimusta",
+      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen.",
+      "default": "Oikaisuvaatimuksen teko ei ole mahdollista sähköisessä asioinnissa. Ole tarvittaessa yhteydessä asiakaspalveluun."
     }
   },
   "parking-fine": {
     "title": "Oikaisuvaatimus pysäköintivirhemaksuun",
-    "fine-info": "Pysäköintivirhemaksun tiedot",
     "stepper": {
       "step1": "Haku",
       "step2": "Pysäköintivirhemaksun tiedot",
@@ -105,7 +109,8 @@
     "submit": "Lähetä",
     "errors": {
       "not-found": "Pysäköintivirhemaksun tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
-      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+      "objection-exists": "Pysäköintivirhemaksuun on jo tehty oikaisuvaatimus. Ole tarvittaessa yhteydessä asiakaspalveluun.",
+      "note": "Huomautus pysäköintivirheestä on maksuton ja siihen ei voi tehdä oikaisuvaatimusta."
     }
   },
   "due-date": {
@@ -135,8 +140,7 @@
     },
     "submit": "Siirrä eräpäivää",
     "errors": {
-      "not-found": "Pysäköintivirhemaksun tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
-      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+      "not-found": "Pysäköintivirhemaksun tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun."
     }
   },
   "moved-car": {
@@ -165,7 +169,7 @@
     "reimbursement-sum": "Korvauspäätöksen summa",
     "errors": {
       "not-found": "Ajoneuvon siirron korvauspäätöksen tietoja ei löydy, tarkista tiedot. Ole tarvittaessa yhteydessä asiakaspalveluun.",
-      "unknown": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen."
+      "objection-exists": "Ajoneuvon siirron korvauspäätökseen on jo tehty oikaisuvaatimus. Ole tarvittaessa yhteydessä asiakaspalveluun."
     }
   },
   "rectificationForm": {

--- a/src/interfaces/foulInterfaces.ts
+++ b/src/interfaces/foulInterfaces.ts
@@ -1,3 +1,17 @@
+export enum ResponseCode {
+  Success,
+  CustomerNotFound,
+  NoVehiclesFoundByRegisterNumber,
+  ParkingPermitNotFound,
+  FoulNotFound,
+  ObjectionExists,
+  TransferNotFound,
+  DueDateExtensionNotPermitted,
+  FoulHasTooManyNoticeChecks,
+  TransferHasTooManyNoticeChecks,
+  FoulIsANote
+}
+
 export interface Foul {
   description: string;
   additionalInfo: string;

--- a/src/utils/interceptors.ts
+++ b/src/utils/interceptors.ts
@@ -5,6 +5,7 @@ import axios, {
   InternalAxiosRequestConfig
 } from 'axios';
 import { clearLoading, setLoading } from '../components/loader/loadingSlice';
+import { ResponseCode } from '../interfaces/foulInterfaces';
 
 let store: AppStore;
 
@@ -42,7 +43,20 @@ const handleResponse = (res: AxiosResponse) => {
   if (store.getState().loading.isLoading) {
     store.dispatch(clearLoading());
   }
-  return res;
+  /* Check that the foul / transfer really exists,
+   * it can be "not found" even though we get a response */
+  if (
+    [ResponseCode.FoulNotFound, ResponseCode.TransferNotFound].includes(
+      res.data.responseCode
+    )
+  ) {
+    const response: AxiosResponse = { ...res, status: 404 };
+    return Promise.reject(
+      new AxiosError(undefined, undefined, undefined, undefined, response)
+    );
+  } else {
+    return res;
+  }
 };
 
 const handleError = (error: AxiosError) => {


### PR DESCRIPTION
This PR adds error handling to foul data and transfer data, for all the errors that come from PASI with status code 200. That is the case when foul/transfer data is found but for some reason the user is not allowed to make a rectification. When this happens, an error notification with the reason is displayed and the 'next' button is disabled.

<img width="982" alt="Screenshot 2023-03-27 at 16 38 18" src="https://user-images.githubusercontent.com/36920208/227954927-9b54cca9-4844-436b-bf5c-d1e5c11a41c9.png">


