### PR TITLE
Send data to /extendDueDate when due date form is submitted

### DIFF
--- a/src/components/extendDueDate/ExtendDueDate.tsx
+++ b/src/components/extendDueDate/ExtendDueDate.tsx
@@ -20,17 +20,13 @@ const ExtendDueDate = (): React.ReactElement => {
     }
   ];
 
-  const handleSubmit = () => {
-    //console.log('submit extend due date form');
-  };
-
   useEffect(() => {
     dispatch(setSelectedForm(FormId.DUEDATE));
   }, [dispatch]);
 
   return (
     <PageContent>
-      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
+      <FormStepper initialSteps={steps} />
     </PageContent>
   );
 };

--- a/src/components/extendDueDate/ExtendDueDateForm.tsx
+++ b/src/components/extendDueDate/ExtendDueDateForm.tsx
@@ -129,7 +129,7 @@ const ExtendDueDateForm = (): React.ReactElement => {
         id="emailConfirmationCheckbox"
         checked={formContent.emailConfirmation}
         onChange={handleCheckedChange}
-        disabled={formContent.submitDisabled}
+        disabled={formContent.submitDisabled || formContent.formSubmitted}
       />
     </div>
   ) : (

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -253,7 +253,6 @@ const FormStepper = (props: Props): React.ReactElement => {
                   id="button-submitted"
                   className="button"
                   iconLeft={<IconThumbsUp />}
-                  onClick={handleSubmit(handleFormSubmit)}
                   variant="success">
                   {t(`${formContent.selectedForm}:submit-success`)}
                 </Button>

--- a/src/components/movedCarAppeal/MovedCarAppeal.tsx
+++ b/src/components/movedCarAppeal/MovedCarAppeal.tsx
@@ -28,17 +28,13 @@ const MovedCarAppeal = (): React.ReactElement => {
     }
   ];
 
-  const handleSubmit = () => {
-    //console.log('submit moved car appeal form');
-  };
-
   useEffect(() => {
     dispatch(setSelectedForm(FormId.MOVEDCAR));
   }, [dispatch]);
 
   return (
     <PageContent>
-      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
+      <FormStepper initialSteps={steps} />
     </PageContent>
   );
 };

--- a/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
+++ b/src/components/parkingFineAppeal/ParkingFineAppeal.tsx
@@ -28,17 +28,13 @@ const ParkingFineAppeal = (): React.ReactElement => {
     }
   ];
 
-  const handleSubmit = () => {
-    //console.log('submit parking fine appeal form');
-  };
-
   useEffect(() => {
     dispatch(setSelectedForm(FormId.PARKINGFINE));
   }, [dispatch]);
 
   return (
     <PageContent>
-      <FormStepper initialSteps={steps} onSubmit={handleSubmit} />
+      <FormStepper initialSteps={steps} />
     </PageContent>
   );
 };

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -104,6 +104,10 @@
       "success": {
         "label": "Olemme vastaanottaneet oikaisuvaatimuksesi",
         "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
+      },
+      "fail": {
+        "label": "Oikaisuvaatimuksen lähetys ei onnistunut",
+        "text": "Jokin meni pieleen oikaisuvaatimuksen lähetyksessä. Ole tarvittaessa yhteydessä asiakaspalveluun."
       }
     },
     "submit": "Lähetä",
@@ -136,6 +140,10 @@
       "success": {
         "label": "Eräpäivää on siirretty",
         "text": "Pysäköintivirhemaksun eräpäivää on siirretty 30 päivää. Uusi eräpäivä on {{newDueDate}}."
+      },
+      "fail": {
+        "label": "Eräpäivän siirto ei onnistunut",
+        "text": "Jokin meni pieleen eräpäivän siirron lähetyksessä. Ole tarvittaessa yhteydessä asiakaspalveluun."
       }
     },
     "submit": "Siirrä eräpäivää",
@@ -161,6 +169,10 @@
       "success": {
         "label": "Olemme vastaanottaneet oikaisuvaatimuksesi",
         "text": "Saat ilmoitukset oikaisuvaatimuksen käsittelyn eri vaiheista antamaasi sähköpostiosoitteeseen. Kun päätös on tehty, saat sen pysäköinnin asiointikansioosi."
+      },
+      "fail": {
+        "label": "Oikaisuvaatimuksen lähetys ei onnistunut",
+        "text": "Jokin meni pieleen oikaisuvaatimuksen lähetyksessä. Ole tarvittaessa yhteydessä asiakaspalveluun."
       }
     },
     "move-timestamp": "Siirron päivämäärä",

--- a/src/interfaces/dueDateInterfaces.ts
+++ b/src/interfaces/dueDateInterfaces.ts
@@ -9,3 +9,17 @@ export enum DueDateExtendableReason {
   HasObjectionsLinked,
   HasPaidCheck
 }
+
+export interface DueDateRequest {
+  foul_number: string;
+  register_number: string;
+}
+
+export interface DueDateResponse {
+  success: boolean;
+  errorcode: string;
+  internalErrorDescription: string;
+  dueDate: string;
+  dueDateExtendableReason: number;
+  responseCode: number;
+}

--- a/src/services/dueDateService.ts
+++ b/src/services/dueDateService.ts
@@ -1,0 +1,15 @@
+import {
+  DueDateResponse,
+  DueDateRequest
+} from '../interfaces/dueDateInterfaces';
+import axios, { AxiosError } from 'axios';
+
+const api_url = window._env_.REACT_APP_API_URL;
+
+export const extendDueDate = async (
+  data: DueDateRequest
+): Promise<DueDateResponse> =>
+  axios
+    .post(`${api_url}/extendDueDate`, data)
+    .then(res => res.data)
+    .catch((err: AxiosError) => Promise.reject(err));


### PR DESCRIPTION
This PR configures the due date form to send a request to `extendDueDate` endpoint when the submit button is clicked.

If the request is successful, a success notification is displayed:
![Screenshot 2023-04-03 at 12 00 28](https://user-images.githubusercontent.com/36920208/229475731-9c603944-b900-4722-b077-32b5fc36150a.png)
Note! The date on the form and the date on the notification are not the same currently, as PASI needs to change the extension from 14 days to 30.

If the request fails for some reason, a fail notification is displayed:
![Screenshot 2023-04-03 at 11 59 45](https://user-images.githubusercontent.com/36920208/229475902-0032329b-dee3-4264-80da-84ef31bc5076.png)
