### PR TITLE
Don't show due date on ParkingFineSummary if foul is a note

### DIFF
--- a/src/components/barcode/Barcode.tsx
+++ b/src/components/barcode/Barcode.tsx
@@ -22,9 +22,9 @@ const Barcode = (props: BarcodeProps) => {
   return (
     <>
       <div className={`barcode-container ${className ? className : ''}`}>
-        <label className="barcode-label">{t('common:barcode:label')}</label>
         {barcode && (
           <>
+            <label className="barcode-label">{t('common:barcode:label')}</label>
             <p className="barcode">{barcode}</p>
             <Button
               data-testid="copy-to-clipboard"

--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { setSubmitDisabled } from '../formContent/formContentSlice';
 import { formatDate, formatDateTime } from '../../utils/helpers';
-import { FoulData, Foul } from '../../interfaces/foulInterfaces';
+import { FoulData, Foul, ResponseCode } from '../../interfaces/foulInterfaces';
 import Barcode from '../barcode/Barcode';
 import '../infoContainer/InfoContainer.css';
 
@@ -91,8 +91,12 @@ const ParkingFineSummary: FC<Props> = ({ foulData }) => {
         </div>
 
         <div className="info-field">
-          <label>{t('common:fine-info:due-date')}</label>
-          <p>{foulData?.dueDate && formatDate(foulData.dueDate)}</p>
+          {foulData?.responseCode !== ResponseCode.FoulIsANote && (
+            <>
+              <label>{t('common:fine-info:due-date')}</label>
+              <p>{foulData?.dueDate && formatDate(foulData.dueDate)}</p>
+            </>
+          )}
         </div>
 
         <hr />

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -439,7 +439,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -471,7 +470,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -500,7 +498,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -530,7 +527,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -559,7 +555,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -588,7 +583,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1251,7 +1245,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1283,7 +1276,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1312,7 +1304,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1342,7 +1333,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1371,7 +1361,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1400,7 +1389,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>


### PR DESCRIPTION
This PR:
* Hides due date field from ParkingFineSummary if foul is a note and thus can't be paid
* Hides bar code field label from ParkingFineSummary if bar code does not exist (usually when foul is a note)

<img width="912" alt="Screenshot 2023-04-12 at 17 01 34" src="https://user-images.githubusercontent.com/36920208/231481937-b5c57fd7-5b7b-4226-986b-10965f80a16d.png">
