### PR TITLE
Send data to /saveObjection when objection form is submitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "graphql.macro": "^1.4.2",
     "hds-core": "1.5.1",
     "hds-design-tokens": "1.5.1",
-    "hds-react": "^2.7.0",
+    "hds-react": "^2.13.0",
     "http-status-typed": "^1.0.0",
     "i18next": "^22.0.2",
     "ibantools": "^4.2.2",

--- a/src/components/formContent/FormContent.test.tsx
+++ b/src/components/formContent/FormContent.test.tsx
@@ -16,6 +16,10 @@ import mockTransferData from '../../mocks/mockTransferData';
 // ClientContext needs to be added here since the tests don't get it from FormStepper
 renderHook(() => useContext(ClientContext));
 
+const mockAction = jest.fn(() => {
+  // Mock function
+});
+
 const dueDateFormContentSliceMock = createSlice({
   name: 'formContent',
   initialState: {
@@ -80,7 +84,14 @@ describe('form content', () => {
   test('passes a11y validation', async () => {
     const { container } = render(
       <Provider store={store}>
-        <FormContent activeStep={0} control={control} values={values} />
+        <FormContent
+          activeStep={0}
+          control={control}
+          values={values}
+          onSubmitPoaFile={mockAction}
+          onSubmitAttachmentFiles={mockAction}
+          formFiles={{ poaFile: [], attachments: [] }}
+        />
       </Provider>
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -98,7 +109,14 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} control={control} values={values} />
+            <FormContent
+              activeStep={0}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
 
@@ -114,7 +132,14 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} control={control} values={values} />
+            <FormContent
+              activeStep={0}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
         await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
@@ -129,7 +154,14 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={0} control={control} values={values} />
+            <FormContent
+              activeStep={0}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
         await waitFor(() => expect(getByTestId('searchForm')).toBeVisible());
@@ -146,7 +178,14 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} control={control} values={values} />
+            <FormContent
+              activeStep={1}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
 
@@ -165,7 +204,14 @@ describe('form content', () => {
 
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} control={control} values={values} />
+            <FormContent
+              activeStep={1}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
 
@@ -183,7 +229,14 @@ describe('form content', () => {
         });
         const { getByTestId } = render(
           <Provider store={store}>
-            <FormContent activeStep={1} control={control} values={values} />
+            <FormContent
+              activeStep={1}
+              control={control}
+              values={values}
+              onSubmitPoaFile={mockAction}
+              onSubmitAttachmentFiles={mockAction}
+              formFiles={{ poaFile: [], attachments: [] }}
+            />
           </Provider>
         );
         await waitFor(() =>

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -17,12 +17,15 @@ import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
 import InfoContainer from '../infoContainer/InfoContainer';
 import RectificationForm from '../rectificationForm/RectificationForm';
 import RectificationSummary from '../rectificationSummary/RectificationSummary';
+import { FormFiles } from '../formStepper/FormStepper';
 import './FormContent.css';
-
 interface Props {
   activeStep: number;
   control: ObjectionControlType;
   values: UseFormGetValues<ObjectionForm>;
+  onSubmitPoaFile: (files: File[]) => void;
+  onSubmitAttachmentFiles: (files: File[]) => void;
+  formFiles: FormFiles;
 }
 
 const FormContent = (props: Props): React.ReactElement => {
@@ -71,7 +74,13 @@ const FormContent = (props: Props): React.ReactElement => {
           0: <SearchForm control={props.control} />,
           1: selectForm(formContent.selectedForm),
           2: (
-            <RectificationForm control={props.control} values={props.values} />
+            <RectificationForm
+              control={props.control}
+              values={props.values}
+              onSubmitPoaFile={props.onSubmitPoaFile}
+              onSubmitAttachmentFiles={props.onSubmitAttachmentFiles}
+              formFiles={props.formFiles}
+            />
           ),
           3: (
             <RectificationSummary
@@ -79,6 +88,7 @@ const FormContent = (props: Props): React.ReactElement => {
               formType={formContent.selectedForm}
               foulData={formContent.foulData}
               transferData={formContent.transferData}
+              formFiles={props.formFiles}
             />
           )
         }[props.activeStep]

--- a/src/components/formContent/FormContent.tsx
+++ b/src/components/formContent/FormContent.tsx
@@ -11,21 +11,22 @@ import {
 import { selectUserProfile } from '../user/userSlice';
 import {
   ObjectionForm,
-  ObjectionControlType
+  ObjectionControlType,
+  ObjectionFormFiles
 } from '../../interfaces/objectionInterfaces';
 import ExtendDueDateForm from '../extendDueDate/ExtendDueDateForm';
 import InfoContainer from '../infoContainer/InfoContainer';
 import RectificationForm from '../rectificationForm/RectificationForm';
 import RectificationSummary from '../rectificationSummary/RectificationSummary';
-import { FormFiles } from '../formStepper/FormStepper';
 import './FormContent.css';
+
 interface Props {
   activeStep: number;
   control: ObjectionControlType;
   values: UseFormGetValues<ObjectionForm>;
   onSubmitPoaFile: (files: File[]) => void;
   onSubmitAttachmentFiles: (files: File[]) => void;
-  formFiles: FormFiles;
+  formFiles: ObjectionFormFiles;
 }
 
 const FormContent = (props: Props): React.ReactElement => {

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -66,12 +66,6 @@ const initialState: FormState = {
     foulNumber: '',
     registerNumber: '',
     authorRole: AuthorRole.Undefined,
-    poaFile: {
-      fileName: '',
-      size: 0,
-      mimeType: '',
-      data: ''
-    },
     attachments: [],
     toSeparateEmail: false,
     newEmail: '',

--- a/src/components/formContent/formContentSlice.tsx
+++ b/src/components/formContent/formContentSlice.tsx
@@ -15,7 +15,11 @@ import {
 } from '../formStepper/formStepperSlice';
 import { DueDateRequest } from '../../interfaces/dueDateInterfaces';
 import { extendDueDate } from '../../services/dueDateService';
-import { ObjectionForm } from '../../interfaces/objectionInterfaces';
+import {
+  AuthorRole,
+  ObjectionForm
+} from '../../interfaces/objectionInterfaces';
+import { saveObjection } from '../../services/objectionService';
 
 export enum FormId {
   NONE = '',
@@ -61,7 +65,7 @@ const initialState: FormState = {
     transferNumber: '',
     foulNumber: '',
     registerNumber: '',
-    authorRole: 0,
+    authorRole: AuthorRole.Undefined,
     poaFile: {
       fileName: '',
       size: 0,
@@ -118,6 +122,21 @@ export const extendDueDateThunk = createAsyncThunk(
   'formContent/extendDueDate',
   async (req: DueDateRequest, thunkAPI) =>
     await extendDueDate(req)
+      .then(res => {
+        const activeStep = (thunkAPI.getState() as RootState).formStepper
+          .activeStepIndex;
+        thunkAPI.dispatch(disablePreviousSteps(activeStep));
+        return res;
+      })
+      .catch((err: AxiosError) =>
+        thunkAPI.rejectWithValue(err.response?.status)
+      )
+);
+
+export const saveObjectionThunk = createAsyncThunk(
+  'formContent/saveObjection',
+  async (req: ObjectionForm, thunkAPI) =>
+    await saveObjection(req)
       .then(res => {
         const activeStep = (thunkAPI.getState() as RootState).formStepper
           .activeStepIndex;
@@ -201,6 +220,16 @@ export const slice = createSlice({
       submitError: false
     }));
     builder.addCase(extendDueDateThunk.rejected, state => ({
+      ...state,
+      submitError: true
+    }));
+    // POST SaveObjection
+    builder.addCase(saveObjectionThunk.fulfilled, state => ({
+      ...state,
+      formSubmitted: true,
+      submitError: false
+    }));
+    builder.addCase(saveObjectionThunk.rejected, state => ({
       ...state,
       submitError: true
     }));

--- a/src/components/formStepper/FormStepper.tsx
+++ b/src/components/formStepper/FormStepper.tsx
@@ -20,7 +20,7 @@ import { friendlyFormatIBAN } from 'ibantools';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import useUserProfile from '../../hooks/useUserProfile';
 import FormContent from '../formContent/FormContent';
-import { formatDate } from '../../utils/helpers';
+import { createObjection, formatDate } from '../../utils/helpers';
 import {
   completeStep,
   selectStepperState,
@@ -35,6 +35,7 @@ import {
   getFoulDataThunk,
   getTransferDataThunk,
   extendDueDateThunk,
+  saveObjectionThunk,
   setSubmitError,
   FormId
 } from '../formContent/formContentSlice';
@@ -99,7 +100,12 @@ const FormStepper = (props: Props): React.ReactElement => {
   const { control, handleSubmit, getValues } = useRectificationForm();
 
   const handleFormSubmit = (form: ObjectionForm) => {
+    const objection = createObjection(formContent.formValues);
     switch (selectedForm) {
+      case FormId.PARKINGFINE:
+        return dispatch(saveObjectionThunk(objection)).then(() =>
+          setShowSubmitNotification(true)
+        );
       case FormId.DUEDATE:
         dispatch(
           extendDueDateThunk({

--- a/src/components/rectificationForm/RectificationForm.test.tsx
+++ b/src/components/rectificationForm/RectificationForm.test.tsx
@@ -15,6 +15,10 @@ const { result } = renderHook(() => useForm<ObjectionForm>());
 const control = result.current.control;
 const values = result.current.getValues;
 
+const mockAction = jest.fn(() => {
+  // Mock function
+});
+
 describe('Component in parking fine appeal form', () => {
   const formContentSliceMock = createSlice({
     name: 'formContent',
@@ -50,7 +54,13 @@ describe('Component in parking fine appeal form', () => {
   it('matches snapshot', async () => {
     const { container } = render(
       <Provider store={store}>
-        <RectificationForm control={control} values={values} />
+        <RectificationForm
+          control={control}
+          values={values}
+          onSubmitPoaFile={mockAction}
+          onSubmitAttachmentFiles={mockAction}
+          formFiles={{ poaFile: [], attachments: [] }}
+        />
       </Provider>
     );
 
@@ -60,7 +70,13 @@ describe('Component in parking fine appeal form', () => {
   it('passes A11y checks', async () => {
     const { container } = render(
       <Provider store={store}>
-        <RectificationForm control={control} values={values} />
+        <RectificationForm
+          control={control}
+          values={values}
+          onSubmitPoaFile={mockAction}
+          onSubmitAttachmentFiles={mockAction}
+          formFiles={{ poaFile: [], attachments: [] }}
+        />
       </Provider>
     );
 
@@ -103,7 +119,13 @@ describe('Component in moved car form', () => {
   it('matches snapshot', async () => {
     const { container } = render(
       <Provider store={store}>
-        <RectificationForm control={control} values={values} />
+        <RectificationForm
+          control={control}
+          values={values}
+          onSubmitPoaFile={mockAction}
+          onSubmitAttachmentFiles={mockAction}
+          formFiles={{ poaFile: [], attachments: [] }}
+        />
       </Provider>
     );
 
@@ -113,7 +135,13 @@ describe('Component in moved car form', () => {
   it('passes A11y checks', async () => {
     const { container } = render(
       <Provider store={store}>
-        <RectificationForm control={control} values={values} />
+        <RectificationForm
+          control={control}
+          values={values}
+          onSubmitPoaFile={mockAction}
+          onSubmitAttachmentFiles={mockAction}
+          formFiles={{ poaFile: [], attachments: [] }}
+        />
       </Provider>
     );
 

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -19,13 +19,13 @@ import useMobileWidth from '../../hooks/useMobileWidth';
 import { FormId, selectFormContent } from '../formContent/formContentSlice';
 import {
   ObjectionForm,
+  ObjectionFormFiles,
   ObjectionControlType,
   AuthorRole
 } from '../../interfaces/objectionInterfaces';
 import { selectUserProfile } from '../user/userSlice';
 import FieldLabel from '../fieldLabel/FieldLabel';
 import ErrorLabel from '../errorLabel/ErrorLabel';
-import { FormFiles } from '../formStepper/FormStepper';
 import './RectificationForm.css';
 
 type Language = 'fi' | 'en' | 'sv';
@@ -35,7 +35,7 @@ interface Props {
   values: UseFormGetValues<ObjectionForm>;
   onSubmitPoaFile: (files: File[]) => void;
   onSubmitAttachmentFiles: (files: File[]) => void;
-  formFiles: FormFiles;
+  formFiles: ObjectionFormFiles;
 }
 
 const RectificationForm: FC<Props> = ({

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -57,7 +57,11 @@ const RectificationForm: FC<Props> = ({
     ? [AuthorRole.Owner, AuthorRole.Possessor]
     : [AuthorRole.Driver, AuthorRole.Owner, AuthorRole.Possessor];
 
-  // Required if POA holder selected as the role
+  // Author role has to be selected
+  const isValidAuthorRole = (field?: string | number) =>
+    field && typeof field === 'string' ? field !== AuthorRole.Undefined : true;
+
+  // Required if POA holder selected as the author role
   const isValidPOAFile = () =>
     values().authorRole !== AuthorRole.Possessor ||
     formFiles.poaFile.length > 0;
@@ -88,102 +92,94 @@ const RectificationForm: FC<Props> = ({
           <Controller
             name="authorRole"
             control={control}
-            rules={{ required: t('common:required-field') as string }}
-            render={({ field, fieldState }) => {
-              const relationField = field;
-              return (
-                <>
-                  <div className="radio-group-section">
-                    <FieldLabel
-                      text={t(`rectificationForm:relation-info:relation`)}
-                      required={true}
-                    />
-                    <div className="radio-group-container">
-                      {relations.map(relation => (
-                        <RadioButton
-                          key={relation}
-                          label={t(
-                            `rectificationForm:relation-info:${relation}`
-                          )}
-                          id={relation}
-                          value={relation}
-                          checked={relation === field.value}
-                          onChange={e => field.onChange(e.target.value)}
-                        />
-                      ))}
-                      {fieldState.error && (
-                        <ErrorLabel text={fieldState.error.message} />
-                      )}
-                    </div>
+            rules={{ validate: isValidAuthorRole }}
+            render={({ field, fieldState }) => (
+              <>
+                <div className="radio-group-section">
+                  <FieldLabel
+                    text={t(`rectificationForm:relation-info:relation`)}
+                    required={true}
+                  />
+                  <div className="radio-group-container">
+                    {relations.map(relation => (
+                      <RadioButton
+                        key={relation}
+                        label={t(`rectificationForm:relation-info:${relation}`)}
+                        id={relation}
+                        value={relation}
+                        checked={relation === field.value}
+                        onChange={e => field.onChange(e.target.value)}
+                      />
+                    ))}
+                    {fieldState.error && (
+                      <ErrorLabel text={t('common:required-field')} />
+                    )}
                   </div>
-                  <div className="rectification-form-user-details">
+                </div>
+                <div className="rectification-form-user-details">
+                  <div>
                     <div>
-                      <div>
-                        <FieldLabel text={t('common:name')} required={true} />
-                        <IconCheckCircle
-                          aria-label={t('common:fetched-from-profile-aria')}
-                          color={'var(--color-info)'}
-                        />
-                      </div>
-                      <p>{`${user?.firstName} ${user?.lastName}`}</p>
-                      <div>
-                        <FieldLabel text={t('common:ssn')} required={true} />
-                        <IconCheckCircle
-                          aria-label={t('common:fetched-from-profile-aria')}
-                          color={'var(--color-info)'}
-                        />
-                      </div>
-                      <p>{user?.ssn}</p>
-                      <div>
-                        <FieldLabel text={t('common:email')} required={true} />
-                        <IconCheckCircle
-                          aria-label={t('common:fetched-from-profile-aria')}
-                          color={'var(--color-info)'}
-                        />
-                      </div>
-                      <p>{user?.email}</p>
+                      <FieldLabel text={t('common:name')} required={true} />
+                      <IconCheckCircle
+                        aria-label={t('common:fetched-from-profile-aria')}
+                        color={'var(--color-info)'}
+                      />
                     </div>
+                    <p>{`${user?.firstName} ${user?.lastName}`}</p>
+                    <div>
+                      <FieldLabel text={t('common:ssn')} required={true} />
+                      <IconCheckCircle
+                        aria-label={t('common:fetched-from-profile-aria')}
+                        color={'var(--color-info)'}
+                      />
+                    </div>
+                    <p>{user?.ssn}</p>
+                    <div>
+                      <FieldLabel text={t('common:email')} required={true} />
+                      <IconCheckCircle
+                        aria-label={t('common:fetched-from-profile-aria')}
+                        color={'var(--color-info)'}
+                      />
+                    </div>
+                    <p>{user?.email}</p>
                   </div>
+                </div>
 
-                  <div className="rectification-poa-fileinput">
-                    <Controller
-                      name="poaFile"
-                      control={control}
-                      rules={{
-                        validate: isValidPOAFile
-                      }}
-                      render={({ field }) => (
-                        <>
-                          <FileInput
-                            language={i18n.language as Language}
-                            label={t('rectificationForm:attach-poa:label')}
-                            id="rectificationPOAFile"
-                            onChange={e => field.onChange(onSubmitPoaFile(e))}
-                            dragAndDrop={!isMobileWidth}
-                            accept={'.jpg, .pdf'}
-                            maxSize={5 * 1024 * 1024}
-                            helperText={t(
-                              'rectificationForm:attach-poa:helper-text'
-                            )}
-                            {...(formFiles.poaFile.length > 0 && {
-                              defaultValue: formFiles.poaFile
-                            })}
+                <div className="rectification-poa-fileinput">
+                  <Controller
+                    name="poaFile"
+                    control={control}
+                    rules={{
+                      validate: isValidPOAFile
+                    }}
+                    render={({ field, fieldState }) => (
+                      <>
+                        <FileInput
+                          language={i18n.language as Language}
+                          label={t('rectificationForm:attach-poa:label')}
+                          id="rectificationPOAFile"
+                          onChange={e => field.onChange(onSubmitPoaFile(e))}
+                          dragAndDrop={!isMobileWidth}
+                          accept={'.jpg, .pdf'}
+                          maxSize={5 * 1024 * 1024}
+                          helperText={t(
+                            'rectificationForm:attach-poa:helper-text'
+                          )}
+                          {...(formFiles.poaFile.length > 0 && {
+                            defaultValue: formFiles.poaFile
+                          })}
+                        />
+                        {fieldState.error && (
+                          <ErrorLabel
+                            text={t('rectificationForm:errors:poa-required')}
                           />
-                          {relationField.value === AuthorRole.Possessor &&
-                            formFiles.poaFile.length === 0 && (
-                              <ErrorLabel
-                                text={t(
-                                  'rectificationForm:errors:poa-required'
-                                )}
-                              />
-                            )}
-                        </>
-                      )}
-                    />
-                  </div>
-                </>
-              );
-            }}
+                        )}
+                      </>
+                    )}
+                  />
+                </div>
+              </>
+            )}
           />
         </div>
         <hr />
@@ -412,7 +408,7 @@ const RectificationForm: FC<Props> = ({
               rules={{
                 validate: numberOfAttachmentsIsValid
               }}
-              render={({ field }) => (
+              render={({ field, fieldState }) => (
                 <>
                   <FileInput
                     language={i18n.language as Language}
@@ -429,7 +425,7 @@ const RectificationForm: FC<Props> = ({
                     maxSize={5 * 1024 * 1024}
                     helperText={t('rectificationForm:attachments:helper-text')}
                   />
-                  {formFiles.attachments.length > 3 && (
+                  {fieldState.error && (
                     <div className="rectification-attachments-error">
                       <ErrorLabel
                         text={t(

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -152,7 +152,7 @@ const RectificationForm: FC<Props> = ({
                     rules={{
                       validate: isValidPOAFile
                     }}
-                    render={({ field, fieldState }) => (
+                    render={({ field }) => (
                       <>
                         <FileInput
                           language={i18n.language as Language}
@@ -169,11 +169,12 @@ const RectificationForm: FC<Props> = ({
                             defaultValue: formFiles.poaFile
                           })}
                         />
-                        {fieldState.error && (
-                          <ErrorLabel
-                            text={t('rectificationForm:errors:poa-required')}
-                          />
-                        )}
+                        {values().authorRole === AuthorRole.Possessor &&
+                          formFiles.poaFile.length === 0 && (
+                            <ErrorLabel
+                              text={t('rectificationForm:errors:poa-required')}
+                            />
+                          )}
                       </>
                     )}
                   />
@@ -408,7 +409,7 @@ const RectificationForm: FC<Props> = ({
               rules={{
                 validate: numberOfAttachmentsIsValid
               }}
-              render={({ field, fieldState }) => (
+              render={({ field }) => (
                 <>
                   <FileInput
                     language={i18n.language as Language}
@@ -425,7 +426,7 @@ const RectificationForm: FC<Props> = ({
                     maxSize={5 * 1024 * 1024}
                     helperText={t('rectificationForm:attachments:helper-text')}
                   />
-                  {fieldState.error && (
+                  {formFiles.attachments.length > 3 && (
                     <div className="rectification-attachments-error">
                       <ErrorLabel
                         text={t(

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -439,7 +439,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -471,7 +470,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -500,7 +498,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -530,7 +527,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -559,7 +555,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -588,7 +583,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1251,7 +1245,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1283,7 +1276,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1312,7 +1304,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1342,7 +1333,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1371,7 +1361,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1400,7 +1389,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>

--- a/src/components/rectificationListDetails/RectificationListDetails.tsx
+++ b/src/components/rectificationListDetails/RectificationListDetails.tsx
@@ -114,6 +114,17 @@ const RectificationListDetails: FC<Props> = ({
                   <RectificationSummary
                     form={form.content}
                     formType={formType}
+                    formFiles={{
+                      attachments: form.content.attachments
+                        ? form.content.attachments.map(
+                            file =>
+                              new File([file.data], file.fileName, {
+                                type: file.mimeType
+                              })
+                          )
+                        : [],
+                      poaFile: []
+                    }}
                   />
                 </div>
               </Dialog.Content>
@@ -134,7 +145,21 @@ const RectificationListDetails: FC<Props> = ({
         )}
       </div>
       <div id="rectification-summary-print" aria-hidden="true">
-        <RectificationSummary form={form.content} formType={formType} />
+        <RectificationSummary
+          form={form.content}
+          formType={formType}
+          formFiles={{
+            attachments: form.content.attachments
+              ? form.content.attachments.map(
+                  file =>
+                    new File([file.data], file.fileName, {
+                      type: file.mimeType
+                    })
+                )
+              : [],
+            poaFile: []
+          }}
+        />
       </div>
     </div>
   );

--- a/src/components/rectificationSummary/RectificationSummary.test.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.test.tsx
@@ -9,6 +9,10 @@ import mockFoulData from '../../mocks/mockFoulData';
 import mockRectificationForm from '../../mocks/mockRectificationForm';
 
 describe('Component', () => {
+  const attachmentMock = {
+    poaFile: [new File([''], 'test.pdf', { type: 'application/pdf' })],
+    attachments: [new File([''], 'test2.jpg', { type: 'image/jpeg' })]
+  };
   it('matches snapshot', async () => {
     const formContentSliceMock = createSlice({
       name: 'formContent',
@@ -47,6 +51,7 @@ describe('Component', () => {
         <RectificationSummary
           form={mockRectificationForm}
           formType="parking-fine"
+          formFiles={attachmentMock}
         />
       </Provider>
     );
@@ -59,6 +64,7 @@ describe('Component', () => {
         <RectificationSummary
           form={mockRectificationForm}
           formType="parking-fine"
+          formFiles={attachmentMock}
         />
       </Provider>
     );

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -5,12 +5,14 @@ import { useTranslation } from 'react-i18next';
 import { formatBytes } from '../../utils/helpers';
 import InfoContainer from '../infoContainer/InfoContainer';
 import CustomAccordion from '../customAccordion/CustomAccordion';
-import { ObjectionForm } from '../../interfaces/objectionInterfaces';
+import {
+  ObjectionForm,
+  ObjectionFormFiles
+} from '../../interfaces/objectionInterfaces';
 import ExtendedTextField from '../extendedTextField/ExtendedTextField';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import { FoulData } from '../../interfaces/foulInterfaces';
 import { TransferData } from '../../interfaces/transferInterfaces';
-import { FormFiles } from '../formStepper/FormStepper';
 import styles from '../styles.module.css';
 import './RectificationSummary.css';
 
@@ -19,7 +21,7 @@ interface Props {
   formType: string;
   foulData?: FoulData;
   transferData?: TransferData;
-  formFiles?: FormFiles;
+  formFiles?: ObjectionFormFiles;
 }
 
 const RectificationSummary: FC<Props> = ({

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -5,11 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { formatBytes } from '../../utils/helpers';
 import InfoContainer from '../infoContainer/InfoContainer';
 import CustomAccordion from '../customAccordion/CustomAccordion';
-import { FileItem, ObjectionForm } from '../../interfaces/objectionInterfaces';
+import { ObjectionForm } from '../../interfaces/objectionInterfaces';
 import ExtendedTextField from '../extendedTextField/ExtendedTextField';
 import useMobileWidth from '../../hooks/useMobileWidth';
 import { FoulData } from '../../interfaces/foulInterfaces';
 import { TransferData } from '../../interfaces/transferInterfaces';
+import { FormFiles } from '../formStepper/FormStepper';
 import styles from '../styles.module.css';
 import './RectificationSummary.css';
 
@@ -18,13 +19,15 @@ interface Props {
   formType: string;
   foulData?: FoulData;
   transferData?: TransferData;
+  formFiles?: FormFiles;
 }
 
 const RectificationSummary: FC<Props> = ({
   form,
   formType,
   foulData,
-  transferData
+  transferData,
+  formFiles
 }) => {
   const { t } = useTranslation();
   const formValues = form;
@@ -33,6 +36,8 @@ const RectificationSummary: FC<Props> = ({
     : formValues?.sendDecisionViaEService
     ? 'toParkingService'
     : 'byMail';
+  const poaFile = formFiles?.poaFile;
+  const attachments = formFiles?.attachments;
 
   return (
     <>
@@ -121,23 +126,21 @@ const RectificationSummary: FC<Props> = ({
               <p>{formValues?.description}</p>
             )}
           </div>
-          {formValues?.attachments && formValues?.attachments.length > 0 && (
+          {attachments && attachments.length > 0 && (
             <div>
               <label className={styles['text-label']}>
                 {t('rectificationForm:attachments:label')}
               </label>
               <ul className="file-list">
-                {formValues?.attachments.map((item: FileItem) => (
-                  <li key={item.fileName} className="file-list-item">
-                    {item.mimeType.startsWith('image') ? (
+                {attachments.map((item: File) => (
+                  <li key={item.name} className="file-list-item">
+                    {item.type.startsWith('image') ? (
                       <IconPhoto aria-hidden />
                     ) : (
                       <IconDocument aria-hidden />
                     )}
                     <div className="file-list-item-title">
-                      <span className="file-list-item-name">
-                        {item.fileName}
-                      </span>
+                      <span className="file-list-item-name">{item.name}</span>
                       {item.size && (
                         <span className="file-list-item-size">
                           ({formatBytes(item.size)})
@@ -149,24 +152,24 @@ const RectificationSummary: FC<Props> = ({
               </ul>
             </div>
           )}
-          {formValues?.poaFile && formValues?.poaFile.fileName && (
+          {poaFile && poaFile.length > 0 && (
             <div>
               <label className={styles['text-label']}>
                 {t('rectificationForm:poa')}
               </label>
               <div className="file-list-item">
-                {formValues?.poaFile.mimeType.startsWith('image') ? (
+                {poaFile[0].type.startsWith('image') ? (
                   <IconPhoto aria-hidden />
                 ) : (
                   <IconDocument aria-hidden />
                 )}
                 <div className="file-list-item-title">
-                  <span className="file-list-item-name">
-                    {formValues?.poaFile.fileName}
-                  </span>
-                  <span className="file-list-item-size">
-                    ({formatBytes(formValues?.poaFile.size)})
-                  </span>
+                  <span className="file-list-item-name">{poaFile[0].name}</span>
+                  {poaFile[0].size && (
+                    <span className="file-list-item-size">
+                      ({formatBytes(poaFile[0].size)})
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -90,7 +90,9 @@ const RectificationSummary: FC<Props> = ({
             id="email"
             label={t('common:email')}
             value={
-              formValues?.newEmail ? formValues?.newEmail : formValues?.email
+              formValues?.toSeparateEmail
+                ? formValues?.newEmail
+                : formValues?.email
             }
             readOnly
           />

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -284,13 +284,7 @@ exports[`Component matches snapshot 1`] = `
               >
                 test2.jpg
               </span>
-              <span
-                class="file-list-item-size"
-              >
-                (
-                49 KB
-                )
-              </span>
+              0
             </div>
           </li>
         </ul>
@@ -333,13 +327,7 @@ exports[`Component matches snapshot 1`] = `
             >
               test.pdf
             </span>
-            <span
-              class="file-list-item-size"
-            >
-              (
-              12 KB
-              )
-            </span>
+            0
           </div>
         </div>
       </div>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -27,8 +27,8 @@
     "log-in": "Kirjaudu sisään",
     "not-logged-in": "Et ole kirjautunut sisään",
     "login-prompt": {
-      "title": "Sessio päättynyt",
-      "body": "Olet kirjautunut ulos toisessa ikkunassa",
+      "title": "Istunto on päättynyt",
+      "body": "Kirjaudu uudelleen sisään jatkaaksesi palvelun käyttöä.",
       "button-label": "Kirjaudu uudelleen"
     },
     "barcode": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -179,8 +179,8 @@
         "text": "Jokin meni pieleen oikaisuvaatimuksen lähetyksessä. Ole tarvittaessa yhteydessä asiakaspalveluun."
       },
       "data-not-found": {
-        "label": "Ajoneuvon siirron tietoja ei löytynyt",
-        "text": "Tähän oikaisuvaatimukseen liittyvän ajoneuvon siirron tietoja ei löytynyt. Ole tarvittaessa yhteydessä asiakaspalveluun."
+        "label": "Korvauspäätöksen tietoja ei löytynyt",
+        "text": "Tähän oikaisuvaatimukseen liittyvän ajoneuvon siirron korvauspäätöksen tietoja ei löytynyt. Ole tarvittaessa yhteydessä asiakaspalveluun."
       }
     },
     "move-timestamp": "Siirron päivämäärä",

--- a/src/interfaces/objectionInterfaces.ts
+++ b/src/interfaces/objectionInterfaces.ts
@@ -94,3 +94,8 @@ export enum ObjectionType {
   Foul,
   Transfer
 }
+
+export interface ObjectionFormFiles {
+  poaFile: File[];
+  attachments: File[];
+}

--- a/src/interfaces/objectionInterfaces.ts
+++ b/src/interfaces/objectionInterfaces.ts
@@ -82,3 +82,15 @@ export interface ObjectionDocument {
   deletable: boolean;
   attachments: FileItem[];
 }
+
+export type ObjectionResponse = {
+  ObjectionNumber: number;
+  ObjectionStatusText: string;
+  FoulRegisterNumber: string;
+  TransferRegisterNumber: string;
+};
+
+export enum ObjectionType {
+  Foul,
+  Transfer
+}

--- a/src/mocks/mockRectificationForm.ts
+++ b/src/mocks/mockRectificationForm.ts
@@ -5,15 +5,6 @@ const mockRectificationForm: ObjectionForm = {
   foulNumber: '123456',
   registerNumber: '',
   authorRole: AuthorRole.Driver,
-  poaFile: {
-    fileName: 'test.pdf',
-    size: 12345,
-    mimeType: 'application/pdf',
-    data: ''
-  },
-  attachments: [
-    { fileName: 'test2.jpg', size: 50100, mimeType: 'image/jpeg', data: '' }
-  ],
   toSeparateEmail: false,
   email: 'test.user@test.fi',
   firstName: 'Test',

--- a/src/services/objectionService.ts
+++ b/src/services/objectionService.ts
@@ -1,4 +1,8 @@
-import { ObjectionDocumentResponse } from '../interfaces/objectionInterfaces';
+import {
+  ObjectionDocumentResponse,
+  ObjectionForm,
+  ObjectionResponse
+} from '../interfaces/objectionInterfaces';
 import axios, { AxiosError } from 'axios';
 
 const api_url = window._env_.REACT_APP_API_URL;
@@ -6,5 +10,13 @@ const api_url = window._env_.REACT_APP_API_URL;
 export const getDocuments = async (): Promise<ObjectionDocumentResponse> =>
   axios
     .get(`${api_url}/getDocuments/`)
+    .then(res => res.data)
+    .catch((err: AxiosError) => Promise.reject(err));
+
+export const saveObjection = async (
+  data: ObjectionForm
+): Promise<ObjectionResponse> =>
+  axios
+    .post(`${api_url}/saveObjection`, data)
     .then(res => res.data)
     .catch((err: AxiosError) => Promise.reject(err));

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable no-magic-numbers */
 
 import { addDays, format, formatISO } from 'date-fns';
 import { FormId } from '../components/formContent/formContentSlice';
@@ -94,7 +93,8 @@ export const createObjection = (
   objection.type = form.foulNumber
     ? ObjectionType.Foul
     : ObjectionType.Transfer;
-  objection.email = form.toSeparateEmail ? form.newEmail : form.email;
+  objection.email =
+    form.toSeparateEmail && form.newEmail ? form.newEmail : form.email;
   objection.attachments = attachments;
   // make sure authorRole is in correct format
   objection.authorRole = Number(objection.authorRole);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -90,6 +90,7 @@ export const createObjection = (
   objection.type = form.foulNumber
     ? ObjectionType.Foul
     : ObjectionType.Transfer;
+  objection.email = form.toSeparateEmail ? form.newEmail : form.email;
   objection.attachments = attachments;
   // make sure authorRole is in correct format
   objection.authorRole = Number(objection.authorRole);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-magic-numbers */
 
 import { addDays, format, formatISO } from 'date-fns';
+import { FormId } from '../components/formContent/formContentSlice';
 import { FoulAttachment } from '../interfaces/foulInterfaces';
 import {
   FileItem,
@@ -72,11 +73,11 @@ export const fileToBase64 = (file: File): Promise<string> =>
   so it can be sent to PASI */
 export const createObjection = (
   form: ObjectionForm,
+  selectedForm: FormId,
   attachments: Array<FileItem>
 ) => {
   // remove unnecessary properties
   const {
-    transferNumber,
     deliveryDecision,
     newEmail,
     newEmailConfirm,
@@ -84,6 +85,9 @@ export const createObjection = (
     toSeparateEmail,
     ...objection
   } = { ...form };
+  selectedForm === FormId.MOVEDCAR
+    ? delete objection.foulNumber
+    : delete objection.transferNumber;
   // add missing properties
   objection.sendDecisionViaEService =
     form.deliveryDecision === 'toParkingService';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,10 +1828,10 @@
     core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.11.2":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+"@babel/runtime@7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2047,6 +2047,11 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
+"@hookform/resolvers@^2.9.11":
+  version "2.9.11"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.11.tgz#9ce96e7746625a89239f68ca57c4f654264c17ef"
+  integrity sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -2408,10 +2413,10 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@popperjs/core@2.5.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
-  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+"@popperjs/core@2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@reach/observe-rect@^1.1.0":
   version "1.2.0"
@@ -3337,6 +3342,16 @@
     "@typescript-eslint/typescript-estree" "5.30.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@^5.56.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
+  integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.0.tgz#bf585ee801ab4ad84db2f840174e171a6bb002c7"
@@ -3344,6 +3359,14 @@
   dependencies:
     "@typescript-eslint/types" "5.30.0"
     "@typescript-eslint/visitor-keys" "5.30.0"
+
+"@typescript-eslint/scope-manager@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
+  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
 
 "@typescript-eslint/type-utils@5.30.0":
   version "5.30.0"
@@ -3359,6 +3382,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.0.tgz#db7d81d585a3da3801432a9c1d2fafbff125e110"
   integrity sha512-vfqcBrsRNWw/LBXyncMF/KrUTYYzzygCSsVqlZ1qGu1QtGs6vMkt3US0VNSQ05grXi5Yadp3qv5XZdYLjpp8ag==
 
+"@typescript-eslint/types@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
+  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
+
 "@typescript-eslint/typescript-estree@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.0.tgz#4565ee8a6d2ac368996e20b2344ea0eab1a8f0bb"
@@ -3366,6 +3394,19 @@
   dependencies:
     "@typescript-eslint/types" "5.30.0"
     "@typescript-eslint/visitor-keys" "5.30.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
+  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -3390,6 +3431,14 @@
   integrity sha512-6WcIeRk2DQ3pHKxU1Ni0qMXJkjO/zLjBymlYBy/53qxe7yjEFSvzKLDToJjURUhSl2Fzhkl4SMXQoETauF74cw==
   dependencies:
     "@typescript-eslint/types" "5.30.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
+  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -4327,7 +4376,7 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6335,32 +6384,34 @@ hds-core@1.5.1:
   resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.5.1.tgz#ed802a7b5a39c242b8aa92cea6bb9f5844ed2eaa"
   integrity sha512-PJy4+RqpxoyQNQOM5dOeeTBiJo4EDukSjvMrJMMMZ9T36Q9n3uxIbtMObPkjhYFvcVwiXD03ZvZ1LDk1VPmMlQ==
 
-hds-core@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.7.0.tgz#2a348a790c3ef12b62990473add629e856fd2d6c"
-  integrity sha512-JH4SIIEIVXA/u2gluWswQI4ut6uZXUXIDviiBTAwgd6iGuacpfoorxFmFjJ1LBmHeViOvpc32f3YhqAk0nkiqQ==
+hds-core@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.13.0.tgz#dee00975686f6a55d32cafdeb89eb76ff3a8dec0"
+  integrity sha512-Ck4lnHAjZ0reBmotzXeMLfGNCVJHe2ZI9wzYFkzXF8LxODZ5sNatepFsAxD5At9WQ4//MKRqpCFfl6Gmnn6jIQ==
 
 hds-design-tokens@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.5.1.tgz#90eb4ce89a311eb85c01d630d305ec1bc7c0d1a2"
   integrity sha512-yvDsLz3lK/PavNijrex+de1137RinfkbAjuggL+wQbLVa5Q1qb1kh59kCZ/0qiVxU/IIS5hkAG6JOzzd0z8Oyg==
 
-hds-react@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.7.0.tgz#bef3bc7dd745c462a6a170968ec51de6f8527e54"
-  integrity sha512-/eAA9axQh//F/+GcBlTemoMA+6Myhpzg0Sbi+tmTqKIJ/5QnLUuY+S7oWCTTsUcwfZpNmlgMYkkSf+SG2Hm2/Q==
+hds-react@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.13.0.tgz#742b8d650bd22c7603586a0222a79f8dee853a6c"
+  integrity sha512-jKnKXq/nG5mgcbDvlnHK3D9/e1ZDEK9XZWII9hwIwJZFY3/K59O2nSpkv3DXq/2ORskLLgxskL7agChtlJSvTw==
   dependencies:
-    "@babel/runtime" "7.11.2"
+    "@babel/runtime" "7.17.9"
     "@emotion/styled-base" "^11.0.0"
+    "@hookform/resolvers" "^2.9.11"
     "@juggle/resize-observer" "3.2.0"
-    "@popperjs/core" "2.5.3"
+    "@popperjs/core" "2.11.5"
     "@react-aria/visually-hidden" "3.2.0"
     "@types/cookie" "^0.4.1"
+    "@typescript-eslint/parser" "^5.56.0"
     cookie "^0.4.1"
     crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "2.7.0"
+    hds-core "2.13.0"
     kashe "1.0.4"
     lodash.get "^4.4.2"
     lodash.isequal "4.5.0"
@@ -6369,15 +6420,17 @@ hds-react@^2.7.0:
     lodash.isundefined "3.0.1"
     lodash.pick "^4.4.0"
     lodash.pickby "^4.6.0"
+    lodash.throttle "^4.1.1"
     lodash.uniqueid "4.0.1"
     lodash.xor "^4.5.0"
     memoize-one "5.2.1"
-    postcss "7.0.36"
+    react-hook-form "^7.43.3"
     react-merge-refs "1.1.0"
-    react-popper "2.2.3"
+    react-popper "2.2.5"
     react-spring "9.3.0"
     react-use-measure "2.0.1"
-    react-virtual "2.2.7"
+    react-virtual "2.10.4"
+    yup "^1.0.2"
 
 he@^1.2.0:
   version "1.2.0"
@@ -7906,6 +7959,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -9205,15 +9263,6 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@7.0.36:
-  version "7.0.36"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
-  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
 postcss@^7.0.35:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
@@ -9346,6 +9395,11 @@ prop-types@^15.7.0, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -9507,6 +9561,11 @@ react-hook-form@^7.41.5:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.5.tgz#dcd0e7438c15044eadc99df6deb889da5858a03b"
   integrity sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==
 
+react-hook-form@^7.43.3:
+  version "7.43.9"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.9.tgz#84b56ac2f38f8e946c6032ccb760e13a1037c66d"
+  integrity sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==
+
 react-i18next@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-12.0.0.tgz#634015a2c035779c5736ae4c2e5c34c1659753b1"
@@ -9535,10 +9594,10 @@ react-merge-refs@1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-popper@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+react-popper@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
@@ -9683,13 +9742,12 @@ react-use-measure@2.0.1:
   dependencies:
     debounce "^1.2.0"
 
-react-virtual@2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.2.7.tgz#01f46e8eb1bfd722edb9a6e01daaef438dd7111f"
-  integrity sha512-ggnuqRwYRuuvFdkpD1tOfC5G4nr5xlZUvvp3b/c9r2Nf14dBXZR49oewESyNQnqyO5JT+offgd4oqugLxxdVsQ==
+react-virtual@2.10.4:
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.10.4.tgz#08712f0acd79d7d6f7c4726f05651a13b24d8704"
+  integrity sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==
   dependencies:
     "@reach/observe-rect" "^1.1.0"
-    ts-toolbelt "^6.4.2"
 
 react@^17.0.2:
   version "17.0.2"
@@ -10594,13 +10652,6 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -10781,6 +10832,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-invariant@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
@@ -10812,6 +10868,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tough-cookie@^4.0.0:
   version "4.0.0"
@@ -10858,11 +10919,6 @@ ts-node@^8.8.2:
     make-error "^1.1.1"
     source-map-support "^0.5.17"
     yn "3.1.1"
-
-ts-toolbelt@^6.4.2:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -10924,6 +10980,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -11618,6 +11679,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.1.1.tgz#49dbcf5ae7693ed0a36ed08a9e9de0a09ac18e6b"
+  integrity sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zen-observable-ts@^1.2.0:
   version "1.2.5"


### PR DESCRIPTION
This PR sends the rectification/objection form values and possible attachments (as base64 strings) to `/saveObjection` when the form is submitted. A success notification is shown when the response has `200` status code, and an error notification otherwise. The possible power of attorney (POA) file is submitted in the `attachments` attribute with other attachments.

Other changes:
* Updated the `hds-react` package to `2.13.0` to get the fixed `FileInput` component

