### PR TITLE
Add monitoring start time to ParkingFineSummary

### DIFF
--- a/src/components/parkingFineSummary/ParkingFineSummary.tsx
+++ b/src/components/parkingFineSummary/ParkingFineSummary.tsx
@@ -38,6 +38,13 @@ interface Props {
 const ParkingFineSummary: FC<Props> = ({ foulData }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const foulTime: string = foulData
+    ? foulData?.monitoringStart
+      ? `${formatDateTime(foulData.monitoringStart)} - ${formatDateTime(
+          foulData.foulDate
+        )}`
+      : `${formatDateTime(foulData.foulDate)}`
+    : '';
 
   useEffect(() => {
     dispatch(setSubmitDisabled(false));
@@ -48,7 +55,7 @@ const ParkingFineSummary: FC<Props> = ({ foulData }) => {
       <div data-testid="parkingFineSummary" className="summary-container">
         <div className="info-field">
           <label>{t('common:fine-info:fine-timestamp')}</label>
-          <p>{foulData?.foulDate && formatDateTime(foulData.foulDate)}</p>
+          <p>{foulTime}</p>
         </div>
         <div className="info-field">
           <label>{t('common:fine-info:ref-number:label')}</label>

--- a/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
+++ b/src/components/parkingFineSummary/__snapshots__/ParkingFineSummary.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Component matches snapshot 1`] = `
           Virheen ajankohta
         </label>
         <p>
-          20.2.2023 klo 9:32
+          20.2.2023 klo 9:27 - 20.2.2023 klo 9:32
         </p>
       </div>
       <div

--- a/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
+++ b/src/components/rectificationForm/__snapshots__/RectificationForm.test.tsx.snap
@@ -439,7 +439,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -471,7 +470,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -500,7 +498,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -530,7 +527,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -559,7 +555,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -588,7 +583,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1251,7 +1245,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1283,7 +1276,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1312,7 +1304,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
             <span
               class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
             >
-               
               *
             </span>
           </label>
@@ -1342,7 +1333,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1371,7 +1361,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>
@@ -1400,7 +1389,6 @@ Liitetiedoston suurin sallittu koko on 5 megatavua.
           <span
             class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
           >
-             
             *
           </span>
         </label>


### PR DESCRIPTION
This PR shows the `monitoringStart` value in `ParkingFineSummary` form (if it exists) in addition to the foul time in this format: `monitoringStart - foulTime`

![Screenshot 2023-04-26 at 12 14 18](https://user-images.githubusercontent.com/36920208/234530224-3a332f72-11bd-4dcf-9ae1-30fe27d71d57.png)
