### PR TITLE
Add validation for phone number and reference number

### DIFF
--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -219,6 +219,7 @@ const RectificationForm: FC<Props> = ({
                     rules={{
                       validate: isValidEmail,
                       pattern: {
+                        /* has to contain @ character and no spaces */
                         value: /^\S+@\S+$/i,
                         message: t('rectificationForm:errors:invalid-email')
                       }
@@ -325,7 +326,12 @@ const RectificationForm: FC<Props> = ({
             name="mobilePhone"
             control={control}
             rules={{
-              required: t('common:required-field') as string
+              required: t('common:required-field') as string,
+              pattern: {
+                /* only numbers, + character (at the start) and spaces allowed */
+                value: /^[ ]*[+]?[ ]*[0-9]+[0-9 ]*$/i,
+                message: t('rectificationForm:errors:invalid-phone')
+              }
             }}
             render={({ field, fieldState }) => (
               <TextInput

--- a/src/components/searchForm/SearchForm.tsx
+++ b/src/components/searchForm/SearchForm.tsx
@@ -32,7 +32,12 @@ const SearchForm = (props: Props): React.ReactElement => {
           name="transferNumber"
           control={props.control}
           rules={{
-            required: t('common:required-field') as string
+            required: t('common:required-field') as string,
+            pattern: {
+              /* only numbers and max 10 characters */
+              value: /^([ ]*[0-9]{1,10}[ ]*)$/i,
+              message: t('rectificationForm:errors:invalid-refnumber')
+            }
           }}
           render={({ field, fieldState }) => (
             <TextInput
@@ -59,7 +64,12 @@ const SearchForm = (props: Props): React.ReactElement => {
           name="foulNumber"
           control={props.control}
           rules={{
-            required: t('common:required-field') as string
+            required: t('common:required-field') as string,
+            pattern: {
+              /* only numbers and max 10 characters */
+              value: /^([ ]*[0-9]{1,10}[ ]*)$/i,
+              message: t('rectificationForm:errors:invalid-refnumber')
+            }
           }}
           render={({ field, fieldState }) => (
             <TextInput

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -231,7 +231,8 @@
       "invalid-email": "Tarkista sähköpostiosoite",
       "invalid-phone": "Tarkista puhelinnumero",
       "invalid-iban": "Tarkista pankkitilinumero",
-      "too-many-attachments": "Voit liittää enintään kolme liitettä"
+      "too-many-attachments": "Voit liittää enintään kolme liitettä",
+      "invalid-refnumber": "Tarkista asianumero"
     }
   },
   "landing-page": {


### PR DESCRIPTION
This PR adds validation for
* reference number field on the first form view:
  * can contain max 10 characters and only numbers
* phone number field on the objection form:
  * can contain one + character at the start, numbers and spaces, but no other characters
  * -> e.g. +358 012 356 and 0501234567 are valid phone numbers