### PR TITLE
remove unused id attribute to fix tests

### DIFF
--- a/src/components/rectificationListRow/RectificationListRow.tsx
+++ b/src/components/rectificationListRow/RectificationListRow.tsx
@@ -90,7 +90,6 @@ const RectificationListRow: FC<Props> = ({ form }): React.ReactElement => {
               ? t('landing-page:list:show-less')
               : t('landing-page:list:show-more')
           }
-          id={`rectification-list-row-button-${form.transaction_id}`}
           className="rectification-list-row-button"
           variant="supplementary"
           size="small"


### PR DESCRIPTION
Fix failing LandingPageTest by removing unused id attribute.