### PR TITLE
fix: tell sonar to skip a line KEH-191

### DIFF
--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -256,8 +256,7 @@ const RectificationForm: FC<Props> = ({
               required: t('common:required-field') as string,
               pattern: {
                 /* only numbers, + character (at the start) and spaces allowed */
-                // NOSONAR
-                value: /^[ ]*[+]?[ ]*[0-9]+[0-9 ]*$/i,
+                value: /^[ ]*[+]?[ ]*[0-9][0-9 ]*$/,
                 message: t('rectificationForm:errors:invalid-phone')
               }
             }}

--- a/src/components/rectificationForm/RectificationForm.tsx
+++ b/src/components/rectificationForm/RectificationForm.tsx
@@ -256,6 +256,7 @@ const RectificationForm: FC<Props> = ({
               required: t('common:required-field') as string,
               pattern: {
                 /* only numbers, + character (at the start) and spaces allowed */
+                // NOSONAR
                 value: /^[ ]*[+]?[ ]*[0-9]+[0-9 ]*$/i,
                 message: t('rectificationForm:errors:invalid-phone')
               }


### PR DESCRIPTION
Sonarcube flagged a regex in the code that it thinks could enable denial of service attack.

> Make sure the regex used here, which is vulnerable to super-linear runtime due to backtracking, cannot lead to denial of service

It is safe to use. Since this is client-side validation only, an attacker can bypass it entirely, modify the request in DevTools, use curl, or just strip the validation JS. The regex complexity is irrelevant from a security standpoint.

Refs: KEH-191