### PR TITLE
feat: add suomifi info to summary page PSA-170

### DIFF
--- a/src/components/rectificationSummary/RectificationSummary.css
+++ b/src/components/rectificationSummary/RectificationSummary.css
@@ -20,6 +20,10 @@
   margin-bottom: var(--spacing-m);
 }
 
+.delivery-decision-info {
+  white-space: pre-line;
+}
+
 .file-list {
   list-style: none;
   margin: var(--spacing-s) 0 0;

--- a/src/components/rectificationSummary/RectificationSummary.tsx
+++ b/src/components/rectificationSummary/RectificationSummary.tsx
@@ -84,6 +84,9 @@ const RectificationSummary: FC<Props> = ({
             <label>{t('rectificationForm:IBAN')}</label>
             <p>{formValues?.iban}</p>
           </div>
+          <div className="delivery-decision-info" data-testid="deliveryDecision">
+            <p>{t('rectificationForm:delivery-decision-info')}</p>
+          </div>
         </div>
         <div className="rectification-summary-contents">
           <div className="rectification-summary-rectification-content">

--- a/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
+++ b/src/components/rectificationSummary/__snapshots__/RectificationSummary.test.tsx.snap
@@ -116,6 +116,14 @@ exports[`Component > matches snapshot 1`] = `
           FI9780001700903330
         </p>
       </div>
+      <div
+        class="delivery-decision-info"
+        data-testid="deliveryDecision"
+      >
+        <p>
+          Päätöksestä ilmoitetaan ensisijaisesti Suomi.fi-palvelun kautta. Jos palvelua ei ole käytössä, päätöksestä ilmoitetaan sähköpostiosoitteeseesi.
+        </p>
+      </div>
     </div>
     <div
       class="rectification-summary-contents"


### PR DESCRIPTION
Add suomifi info text also to summary page. 

Continues this PR: https://github.com/City-of-Helsinki/pysakoinnin-sahk-asiointi-ui/pull/257


Ref: PSA-170